### PR TITLE
feat: new parameters added and new jupyter notebook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@
 
 ## Key Features
 
-- Python models for bulletin entries.
-- High-level client API for date-based DOUE queries.
-- Built-in parsing from raw SPARQL JSON to dataclasses.
-- Custom exception hierarchy for query and endpoint failures.
-- Test suite with unit and integration coverage.
+- Query official acts from Legal Institutions.
+- Works with Python objects instead of raw JSON and gets away from Web Services.
+- Easier for data manipulation and integration in notebooks through Python models.
+- Keep a clean architecture with a public API layer and a data connector layer.
 
 ## Installation
 
@@ -43,14 +42,13 @@ Fetch acts for a publication date:
 from bulletin.doue.api.client import DoueBulletinClient
 
 client = DoueBulletinClient()
-acts = client.get_acts("2025-03-27", language="ENG")
+acts = client.get_acts(date="2025-03-31")
 
 print(f"Total acts: {len(acts)}")
 if acts:
  first = acts[0]
  print(first.celex_uri)
  print(first.title)
- print(first.date)
 ```
 
 ### Standalone Script
@@ -58,7 +56,7 @@ if acts:
 The repository includes a runnable script:
 
 ```bash
-python scripts/run_doue.py 2025-03-27 --language ENG
+python scripts/run_doue.py
 ```
 
 ## Contributing
@@ -81,10 +79,6 @@ For any questions or suggestions, feel free to reach out to the author:
 
 - **Author**: Diego González Suárez
 - **Email**: <gonzalezsdiego@uniovi.es>
-
-## Acknowledgements
-
-- EUR-Lex / Cellar SPARQL endpoint
-- MkDocs and Material for MkDocs
+- **GitHub**: [diegoglezsu](https://github.com/diegoglezsu)
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,12 +25,11 @@ pip install -e .[dev]
 from bulletin.doue.api.client import DoueBulletinClient
 
 client = DoueBulletinClient()
-acts = client.get_acts("2025-03-27", language="ENG")
+acts = client.get_acts(date="2025-03-27")
 
 for act in acts[:3]:
  print(act.celex_uri)
  print(act.title)
- print(act.date)
 ```
 
 ### Run the Example Script
@@ -38,5 +37,5 @@ for act in acts[:3]:
 The [repository](https://github.com/diegoglezsu/bulletin-fetcher/tree/main/scripts) includes an executable helper script:
 
 ```bash
-python scripts/run_doue.py 2025-03-27 --language ENG
+python scripts/run_doue.py
 ```

--- a/scripts/run_doue.ipynb
+++ b/scripts/run_doue.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "ad128444",
    "metadata": {},
    "outputs": [
@@ -62,9 +62,6 @@
     "\n",
     "print(f\"Total acts: {len(acts)}\")\n",
     "print(\"Done.\")\n",
-    "#csv_output = client.get_acts_csv(date=date, date_end=date_end, language=language)  # Example of fetching CSV output\n",
-    "#print(\"CSV Output:\")\n",
-    "#print(csv_output)\n",
     "\n"
    ]
   },

--- a/scripts/run_doue.ipynb
+++ b/scripts/run_doue.ipynb
@@ -1,0 +1,168 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8e8e6a2e",
+   "metadata": {},
+   "source": [
+    "## Notebook usage example\n",
+    "\n",
+    "This is an example of a notebook usage. You can write your code to test the library here"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ad128444",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------------------------------------\n",
+      "DoueOfficialAct(celex_uri='http://publications.europa.eu/resource/celex/22026P01110', act_number='1110', title='Resolución de la Asamblea Parlamentaria Euronest sobre la promoción del comercio justo, la cooperación y las inversiones entre la Unión y los países de la Asociación Oriental en apoyo a la conectividad, la transición ecológica y el desarrollo de infraestructuras, aprobada el 30\\xa0de\\xa0octubre de\\xa02025', date=datetime.date(2026, 2, 26), section_code='I', subsection_code='a', category_code='RES', category_uri='http://publications.europa.eu/resource/authority/resource-type/RES', category_label='Resolución', institution_code='EURONEST', institution_uri='http://publications.europa.eu/resource/authority/corporate-body/EURONEST', institution_label='Asamblea Parlamentaria Euronest')\n",
+      "------------------------------------------------------------\n",
+      "DoueOfficialAct(celex_uri='http://publications.europa.eu/resource/celex/22026P01112', act_number='1112', title='Resolución de la Asamblea Parlamentaria Euronest sobre Horizonte Europa: un gran programa abierto a los mejores investigadores, aprobada el 30\\xa0de\\xa0octubre de\\xa02025', date=datetime.date(2026, 2, 26), section_code='I', subsection_code='a', category_code='RES', category_uri='http://publications.europa.eu/resource/authority/resource-type/RES', category_label='Resolución', institution_code='EURONEST', institution_uri='http://publications.europa.eu/resource/authority/corporate-body/EURONEST', institution_label='Asamblea Parlamentaria Euronest')\n",
+      "------------------------------------------------------------\n",
+      "DoueOfficialAct(celex_uri='http://publications.europa.eu/resource/celex/22026P01111', act_number='1111', title='Resolución de la Asamblea Parlamentaria Euronest sobre el difícil paradigma de los sistemas energéticos interrelacionados: hacia un futuro más sostenible en los países de la Asociación Oriental, aprobada el 30\\xa0de\\xa0octubre de\\xa02025', date=datetime.date(2026, 2, 26), section_code='I', subsection_code='a', category_code='RES', category_uri='http://publications.europa.eu/resource/authority/resource-type/RES', category_label='Resolución', institution_code='EURONEST', institution_uri='http://publications.europa.eu/resource/authority/corporate-body/EURONEST', institution_label='Asamblea Parlamentaria Euronest')\n",
+      "------------------------------------------------------------\n",
+      "DoueOfficialAct(celex_uri='http://publications.europa.eu/resource/celex/22026P01109', act_number='1109', title='Resolución de la Asamblea Parlamentaria Euronest sobre el futuro de la Asociación Oriental y las nuevas perspectivas de la política de ampliación de la Unión: hacia la necesidad de paz, seguridad y estabilidad en la región, adoptada el 30\\xa0de\\xa0octubre de\\xa02025', date=datetime.date(2026, 2, 26), section_code='I', subsection_code='a', category_code='RES', category_uri='http://publications.europa.eu/resource/authority/resource-type/RES', category_label='Resolución', institution_code='EURONEST', institution_uri='http://publications.europa.eu/resource/authority/corporate-body/EURONEST', institution_label='Asamblea Parlamentaria Euronest')\n",
+      "------------------------------------------------------------\n",
+      "DoueOfficialAct(celex_uri='http://publications.europa.eu/resource/celex/22026P01113', act_number='1113', title='Resolución de la Asamblea Parlamentaria Euronest sobre la apertura de grupos de capítulos de negociación para Ucrania y Moldavia en el marco del proceso de negociación para la adhesión a la Unión Europea, adoptada el 30\\xa0de\\xa0octubre de\\xa02025', date=datetime.date(2026, 2, 26), section_code='I', subsection_code='a', category_code='RES', category_uri='http://publications.europa.eu/resource/authority/resource-type/RES', category_label='Resolución', institution_code='EURONEST', institution_uri='http://publications.europa.eu/resource/authority/corporate-body/EURONEST', institution_label='Asamblea Parlamentaria Euronest')\n",
+      "------------------------------------------------------------\n",
+      "Total acts: 5\n",
+      "Done.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "\n",
+    "from bulletin.doue.api.client import DoueBulletinClient\n",
+    "\n",
+    "\n",
+    "client = DoueBulletinClient()\n",
+    "\n",
+    "date = \"2026-01-01\"\n",
+    "date_end = \"2026-03-31\"\n",
+    "title_contains = \"euronest\"\n",
+    "language = \"SPA\"\n",
+    "\n",
+    "try:\n",
+    "    acts = client.get_acts(date=date, language=language, date_end=date_end, title_contains=title_contains)\n",
+    "except Exception as exc:\n",
+    "    print(f\"Error while fetching acts: {exc}\", file=sys.stderr)\n",
+    "\n",
+    "print(\"-\" * 60)\n",
+    "\n",
+    "for act in acts:\n",
+    "    print(act)\n",
+    "    print(\"-\" * 60)\n",
+    "\n",
+    "print(f\"Total acts: {len(acts)}\")\n",
+    "print(\"Done.\")\n",
+    "#csv_output = client.get_acts_csv(date=date, date_end=date_end, language=language)  # Example of fetching CSV output\n",
+    "#print(\"CSV Output:\")\n",
+    "#print(csv_output)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "fda90356",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CSV Output:\n",
+      "\"celex_uri\",\"act_number\",\"title\",\"date\",\"section_code\",\"subsection_code\",\"category_code\",\"category_uri\",\"category_label\",\"institution_code\",\"institution_uri\",\"institution_label\"\n",
+      "\"http://publications.europa.eu/resource/celex/22026P01110\",\"1110\",\"Resolución de la Asamblea Parlamentaria Euronest sobre la promoción del comercio justo, la cooperación y las inversiones entre la Unión y los países de la Asociación Oriental en apoyo a la conectividad, la transición ecológica y el desarrollo de infraestructuras, aprobada el 30 de octubre de 2025\",\"2026-02-26\",\"I\",\"a\",\"RES\",\"http://publications.europa.eu/resource/authority/resource-type/RES\",\"Resolución\",\"EURONEST\",\"http://publications.europa.eu/resource/authority/corporate-body/EURONEST\",\"Asamblea Parlamentaria Euronest\"\n",
+      "\"http://publications.europa.eu/resource/celex/22026P01112\",\"1112\",\"Resolución de la Asamblea Parlamentaria Euronest sobre Horizonte Europa: un gran programa abierto a los mejores investigadores, aprobada el 30 de octubre de 2025\",\"2026-02-26\",\"I\",\"a\",\"RES\",\"http://publications.europa.eu/resource/authority/resource-type/RES\",\"Resolución\",\"EURONEST\",\"http://publications.europa.eu/resource/authority/corporate-body/EURONEST\",\"Asamblea Parlamentaria Euronest\"\n",
+      "\"http://publications.europa.eu/resource/celex/22026P01111\",\"1111\",\"Resolución de la Asamblea Parlamentaria Euronest sobre el difícil paradigma de los sistemas energéticos interrelacionados: hacia un futuro más sostenible en los países de la Asociación Oriental, aprobada el 30 de octubre de 2025\",\"2026-02-26\",\"I\",\"a\",\"RES\",\"http://publications.europa.eu/resource/authority/resource-type/RES\",\"Resolución\",\"EURONEST\",\"http://publications.europa.eu/resource/authority/corporate-body/EURONEST\",\"Asamblea Parlamentaria Euronest\"\n",
+      "\"http://publications.europa.eu/resource/celex/22026P01109\",\"1109\",\"Resolución de la Asamblea Parlamentaria Euronest sobre el futuro de la Asociación Oriental y las nuevas perspectivas de la política de ampliación de la Unión: hacia la necesidad de paz, seguridad y estabilidad en la región, adoptada el 30 de octubre de 2025\",\"2026-02-26\",\"I\",\"a\",\"RES\",\"http://publications.europa.eu/resource/authority/resource-type/RES\",\"Resolución\",\"EURONEST\",\"http://publications.europa.eu/resource/authority/corporate-body/EURONEST\",\"Asamblea Parlamentaria Euronest\"\n",
+      "\"http://publications.europa.eu/resource/celex/22026P01113\",\"1113\",\"Resolución de la Asamblea Parlamentaria Euronest sobre la apertura de grupos de capítulos de negociación para Ucrania y Moldavia en el marco del proceso de negociación para la adhesión a la Unión Europea, adoptada el 30 de octubre de 2025\",\"2026-02-26\",\"I\",\"a\",\"RES\",\"http://publications.europa.eu/resource/authority/resource-type/RES\",\"Resolución\",\"EURONEST\",\"http://publications.europa.eu/resource/authority/corporate-body/EURONEST\",\"Asamblea Parlamentaria Euronest\"\n",
+      "\n",
+      "                                           celex_uri  act_number  \\\n",
+      "0  http://publications.europa.eu/resource/celex/2...        1110   \n",
+      "1  http://publications.europa.eu/resource/celex/2...        1112   \n",
+      "2  http://publications.europa.eu/resource/celex/2...        1111   \n",
+      "3  http://publications.europa.eu/resource/celex/2...        1109   \n",
+      "4  http://publications.europa.eu/resource/celex/2...        1113   \n",
+      "\n",
+      "                                               title        date section_code  \\\n",
+      "0  Resolución de la Asamblea Parlamentaria Eurone...  2026-02-26            I   \n",
+      "1  Resolución de la Asamblea Parlamentaria Eurone...  2026-02-26            I   \n",
+      "2  Resolución de la Asamblea Parlamentaria Eurone...  2026-02-26            I   \n",
+      "3  Resolución de la Asamblea Parlamentaria Eurone...  2026-02-26            I   \n",
+      "4  Resolución de la Asamblea Parlamentaria Eurone...  2026-02-26            I   \n",
+      "\n",
+      "  subsection_code category_code  \\\n",
+      "0               a           RES   \n",
+      "1               a           RES   \n",
+      "2               a           RES   \n",
+      "3               a           RES   \n",
+      "4               a           RES   \n",
+      "\n",
+      "                                        category_uri category_label  \\\n",
+      "0  http://publications.europa.eu/resource/authori...     Resolución   \n",
+      "1  http://publications.europa.eu/resource/authori...     Resolución   \n",
+      "2  http://publications.europa.eu/resource/authori...     Resolución   \n",
+      "3  http://publications.europa.eu/resource/authori...     Resolución   \n",
+      "4  http://publications.europa.eu/resource/authori...     Resolución   \n",
+      "\n",
+      "  institution_code                                    institution_uri  \\\n",
+      "0         EURONEST  http://publications.europa.eu/resource/authori...   \n",
+      "1         EURONEST  http://publications.europa.eu/resource/authori...   \n",
+      "2         EURONEST  http://publications.europa.eu/resource/authori...   \n",
+      "3         EURONEST  http://publications.europa.eu/resource/authori...   \n",
+      "4         EURONEST  http://publications.europa.eu/resource/authori...   \n",
+      "\n",
+      "                 institution_label  \n",
+      "0  Asamblea Parlamentaria Euronest  \n",
+      "1  Asamblea Parlamentaria Euronest  \n",
+      "2  Asamblea Parlamentaria Euronest  \n",
+      "3  Asamblea Parlamentaria Euronest  \n",
+      "4  Asamblea Parlamentaria Euronest  \n"
+     ]
+    }
+   ],
+   "source": [
+    "# Add acts to a dataframe\n",
+    "csv = client.get_acts_csv(date=date, language=language, date_end=date_end, title_contains=title_contains)\n",
+    "print(\"CSV Output:\")\n",
+    "print(csv)\n",
+    "# You can use pandas to read the CSV output into a DataFrame\n",
+    "import pandas as pd\n",
+    "import io\n",
+    "\n",
+    "df = pd.read_csv(io.StringIO(csv))\n",
+    "print(df.head())\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/run_doue.py
+++ b/scripts/run_doue.py
@@ -1,39 +1,24 @@
 """Small script to query DOUE acts using bulletin-fetcher."""
 
-import argparse
 import sys
 
 from bulletin.doue.api.client import DoueBulletinClient
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Fetch Official Journal (DOUE) acts by publication date."
-    )
-    parser.add_argument(
-        "date",
-        help="Publication date in YYYY-MM-DD format, e.g. 2025-03-27",
-    )
-    parser.add_argument(
-        "--language",
-        default="ENG",
-        help="EU language code (default: ENG)",
-    )
-    return parser
-
-
 def main() -> int:
-    parser = build_parser()
-    args = parser.parse_args()
 
     client = DoueBulletinClient()
 
+    date = "2026-01-01"
+    date_end = "2026-03-31"
+    title_contains = "euronest"
+    language = "SPA"
+
     try:
-        acts = client.get_acts(args.date, language=args.language)
+        acts = client.get_acts(date=date, language=language, date_end=date_end, title_contains=title_contains)
     except Exception as exc:
         print(f"Error while fetching acts: {exc}", file=sys.stderr)
         return 1
 
-    print(f"Total acts: {len(acts)}")
     print("-" * 60)
 
     for act in acts:
@@ -46,9 +31,11 @@ def main() -> int:
             print(f"Institution: {act.institution_label}")
         print("-" * 60)
 
-    csv_output = client.get_acts_csv(args.date, language=args.language)  # Example of fetching CSV output
-    print("CSV Output:")
-    print(csv_output)
+    print(f"Total acts: {len(acts)}")
+    print("Done.")
+    #csv_output = client.get_acts_csv(date=date, date_end=date_end, language=language)  # Example of fetching CSV output
+    #print("CSV Output:")
+    #print(csv_output)
 
     return 0
 

--- a/src/bulletin/doue/api/client.py
+++ b/src/bulletin/doue/api/client.py
@@ -15,31 +15,35 @@ class DoueBulletinClient:
         self._connector = DoueConnector(endpoint=endpoint, timeout=timeout)
 
     def get_acts(
-        self, date: str, language: str = DEFAULT_LANGUAGE
+        self, date: str, language: str = DEFAULT_LANGUAGE, date_end: str | None = None, title_contains: str | None = None
     ) -> list[DoueOfficialAct]:
         """Fetch Official Journal acts for a given publication date.
 
         Args:
             date: Publication date in ISO format (e.g. "2025-03-27").
+            date_end: End date in ISO format (e.g. "2025-03-27"). If provided, fetch acts published between `date` and `date_end` inclusive.
+            title_contains: Case-insensitive substring filter on title.
             language: Language code (default: "ENG"). Supported values are defined in `LANGUAGE_CODE_MAP`. Examples: "ENG", "FRA", "DEU", "SPA"...
 
         Returns:
             A list of DoueOfficialAct objects.
         """
-        query = self._connector.build_acts_query(date, language=language)
+        query = self._connector.build_acts_query(date, language=language, date_end=date_end, title_contains=title_contains)
         response = self._connector.execute_query(query)
         return parse_results(response)
 
-    def get_acts_csv(self, date: str, language: str = DEFAULT_LANGUAGE) -> str:
+    def get_acts_csv(self, date: str, date_end: str | None = None, title_contains: str | None = None, language: str = DEFAULT_LANGUAGE) -> str:
         """
         Fetch Official Journal acts for a given date and return CSV output.
 
         Args:
             date: Publication date in ISO format (e.g. "2025-03-27").
+            date_end: End date in ISO format (e.g. "2025-03-27"). If provided, fetch acts published between `date` and `date_end` inclusive.
+            title_contains: Case-insensitive substring filter on title.
             language: Language code (default: "ENG"). Supported values are defined in `LANGUAGE_CODE_MAP`. Example: "ENG", "FRA", "DEU", "SPA".
         Returns:
             A string containing the CSV representation of the acts.
 
         """
-        acts = self.get_acts(date, language=language)
+        acts = self.get_acts(date, language=language, date_end=date_end, title_contains=title_contains)
         return acts_to_csv(acts)

--- a/src/bulletin/doue/repository/_connector.py
+++ b/src/bulletin/doue/repository/_connector.py
@@ -4,6 +4,7 @@ Connector for the EUR-Lex / Cellar SPARQL endpoint.
 Handles query building and HTTP communication.
 """
 
+from datetime import date
 import requests
 
 from ..constants import SPARQL_ENDPOINT, LANGUAGE_CODE_MAP, DEFAULT_LANGUAGE
@@ -17,11 +18,19 @@ class DoueConnector:
         self.endpoint = endpoint
         self.timeout = timeout
 
-    def build_acts_query(self, date: str, language: str = DEFAULT_LANGUAGE) -> str:
+    def build_acts_query(
+        self,
+        date: str,
+        language: str = DEFAULT_LANGUAGE,
+        date_end: str | None = None,
+        title_contains: str | None = None,
+    ) -> str:
         """Build a SPARQL query for Official Journal acts on a given date.
 
         Args:
             date: Publication date in ISO format (e.g. "2025-03-27").
+            date_end: End date in ISO format (YYYY-MM-DD). If provided, fetch acts published between `date` and `date_end` inclusive.
+            title_contains: Case-insensitive substring filter on title.
             language: ISO language code (default: "ENG").
 
         Returns:
@@ -31,8 +40,17 @@ class DoueConnector:
             QueryError: If the date format is invalid.
         """
         # Basic validation
-        if not date or len(date) != 10 or date[4] != "-" or date[7] != "-":
-            raise QueryError(f"Invalid date format: '{date}'. Expected YYYY-MM-DD.")
+        _validate_date(date)
+
+        if date_end is not None:
+            _validate_date(date_end)
+            if _parse_date(date_end) < _parse_date(date):
+                raise QueryError("date_end must be on or after date.")
+
+        if title_contains is not None:
+            title_contains = title_contains.strip()
+            if not title_contains:
+                raise QueryError("title_contains filter cannot be empty.")
 
         lang_code = LANGUAGE_CODE_MAP.get(language)
         if lang_code is None:
@@ -44,6 +62,8 @@ class DoueConnector:
         language_uri = (
             f"http://publications.europa.eu/resource/authority/language/{language}"
         )
+
+        filters: list[str] = self._get_filters(date, date_end, title_contains)
 
         return f"""
 PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
@@ -93,8 +113,7 @@ WHERE {{
     AS ?institutionCode
   )
 
-  FILTER(?date = "{date}"^^xsd:date)
-  FILTER(STRSTARTS(STR(?act), "http://publications.europa.eu/resource/celex/"))
+    {"\n  ".join(filters)}
 
   OPTIONAL {{ ?c_act cdm:official-journal-act_number ?actNumber . }}
 }}
@@ -133,3 +152,39 @@ ORDER BY ?sectionCode ?subsectionCode ?categoryLabel ?institutionLabel
                 f"Failed to reach SPARQL endpoint: {e}",
                 endpoint=self.endpoint,
             ) from e
+
+
+    def _get_filters(self, date: str, date_end: str | None, title_contains: str | None) -> list[str]:
+        filters: list[str] = []
+        if date_end is not None:
+            filters.append(f'FILTER(?date >= "{date}"^^xsd:date)')
+            filters.append(f'FILTER(?date <= "{date_end}"^^xsd:date)')
+        else:
+            filters.append(f'FILTER(?date = "{date}"^^xsd:date)')
+
+        if title_contains is not None:
+            escaped_title = _escape_sparql_literal(title_contains)
+            filters.append(
+                f'FILTER(CONTAINS(LCASE(STR(?title)), LCASE("{escaped_title}")))'
+            )
+
+        filters.append(
+            'FILTER(STRSTARTS(STR(?act), "http://publications.europa.eu/resource/celex/"))'
+        )
+        return filters
+
+
+def _validate_date(value: str) -> None:
+    if not value or len(value) != 10 or value[4] != "-" or value[7] != "-":
+        raise QueryError(f"Invalid date format: '{value}'. Expected YYYY-MM-DD.")
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise QueryError(f"Invalid date format: '{value}'. Expected YYYY-MM-DD.") from exc
+
+
+def _escape_sparql_literal(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', "\\\"")

--- a/src/bulletin/doue/repository/_connector.py
+++ b/src/bulletin/doue/repository/_connector.py
@@ -113,7 +113,7 @@ WHERE {{
     AS ?institutionCode
   )
 
-    {"\n  ".join(filters)}
+  {f"\n  ".join(filters)}
 
   OPTIONAL {{ ?c_act cdm:official-journal-act_number ?actNumber . }}
 }}

--- a/src/bulletin/doue/repository/_connector.py
+++ b/src/bulletin/doue/repository/_connector.py
@@ -65,7 +65,7 @@ class DoueConnector:
 
         filters: list[str] = self._get_filters(date, date_end, title_contains)
 
-        return f"""
+        query_template = """
 PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
@@ -113,12 +113,17 @@ WHERE {{
     AS ?institutionCode
   )
 
-  {f"\n  ".join(filters)}
+  {filters_str}
 
   OPTIONAL {{ ?c_act cdm:official-journal-act_number ?actNumber . }}
 }}
 ORDER BY ?sectionCode ?subsectionCode ?categoryLabel ?institutionLabel
 """
+        return query_template.format(
+            language_uri=language_uri,
+            lang_code=lang_code,
+            filters_str="\n  ".join(filters),
+        )
 
     def execute_query(self, query: str) -> dict:
         """Send a SPARQL query to the endpoint and return the JSON response.

--- a/tests/doue/test_client.py
+++ b/tests/doue/test_client.py
@@ -84,7 +84,7 @@ def test_get_acts_with_valid_date(client, mock_connector):
         result = client.get_acts(test_date)
 
         mock_instance.build_acts_query.assert_called_once_with(
-            test_date, language="ENG"
+            test_date, language="ENG", date_end=None, title_contains=None
         )
         mock_instance.execute_query.assert_called_once_with("SPARQL_QUERY")
         mock_parse.assert_called_once_with(mock_response)
@@ -104,7 +104,7 @@ def test_get_acts_with_custom_language(client, mock_connector):
         client.get_acts(test_date, language=custom_language)
 
         mock_instance.build_acts_query.assert_called_once_with(
-            test_date, language=custom_language
+            test_date, language=custom_language, date_end=None, title_contains=None
         )
 
 
@@ -169,6 +169,58 @@ def test_get_acts_empty_results(client, mock_connector):
         assert result == []
 
 
+def test_get_acts_with_date_end(client, mock_connector):
+    """Test fetching acts with a date range using date_end parameter."""
+    test_date = "2025-03-27"
+    test_date_end = "2025-03-31"
+    mock_instance = mock_connector.return_value
+    mock_instance.build_acts_query.return_value = "SPARQL_QUERY"
+    mock_instance.execute_query.return_value = {"results": {"bindings": []}}
+
+    with patch("bulletin.doue.api.client.parse_results") as mock_parse:
+        mock_parse.return_value = []
+        client.get_acts(test_date, date_end=test_date_end)
+
+        mock_instance.build_acts_query.assert_called_once_with(
+            test_date, language="ENG", date_end=test_date_end, title_contains=None
+        )
+
+
+def test_get_acts_with_title_contains(client, mock_connector):
+    """Test fetching acts with a title filter using title_contains parameter."""
+    test_date = "2025-03-27"
+    title_filter = "regulation"
+    mock_instance = mock_connector.return_value
+    mock_instance.build_acts_query.return_value = "SPARQL_QUERY"
+    mock_instance.execute_query.return_value = {"results": {"bindings": []}}
+
+    with patch("bulletin.doue.api.client.parse_results") as mock_parse:
+        mock_parse.return_value = []
+        client.get_acts(test_date, title_contains=title_filter)
+
+        mock_instance.build_acts_query.assert_called_once_with(
+            test_date, language="ENG", date_end=None, title_contains=title_filter
+        )
+
+
+def test_get_acts_with_date_end_and_title_contains(client, mock_connector):
+    """Test fetching acts with both date_end and title_contains parameters."""
+    test_date = "2025-03-27"
+    test_date_end = "2025-03-31"
+    title_filter = "directive"
+    mock_instance = mock_connector.return_value
+    mock_instance.build_acts_query.return_value = "SPARQL_QUERY"
+    mock_instance.execute_query.return_value = {"results": {"bindings": []}}
+
+    with patch("bulletin.doue.api.client.parse_results") as mock_parse:
+        mock_parse.return_value = []
+        client.get_acts(test_date, date_end=test_date_end, title_contains=title_filter)
+
+        mock_instance.build_acts_query.assert_called_once_with(
+            test_date, language="ENG", date_end=test_date_end, title_contains=title_filter
+        )
+
+
 def test_get_acts_csv_returns_csv(client) -> None:
     """Test get_acts_csv returns CSV text."""
     test_date = "2025-03-27"
@@ -194,4 +246,37 @@ def test_get_acts_csv_returns_csv(client) -> None:
 
     assert "\"celex_uri\",\"act_number\",\"title\",\"date\"" in csv_text
     assert "\"https://example.com/act1\",\"2025/1\",\"Act 1\",\"2025-03-27\"" in csv_text
-    mock_get.assert_called_once_with(test_date, language="ENG")
+    mock_get.assert_called_once_with(test_date, language="ENG", date_end=None, title_contains=None)
+
+
+def test_get_acts_csv_with_date_end_and_title_contains(client) -> None:
+    """Test get_acts_csv with date_end and title_contains parameters."""
+    test_date = "2025-03-27"
+    test_date_end = "2025-03-31"
+    title_filter = "regulation"
+    acts = [
+        DoueOfficialAct(
+            celex_uri="https://example.com/act1",
+            act_number="2025/1",
+            title="Regulation about X",
+            date=date(2025, 3, 27),
+            section_code=None,
+            subsection_code=None,
+            category_code=None,
+            category_uri=None,
+            category_label=None,
+            institution_code=None,
+            institution_uri=None,
+            institution_label=None,
+        )
+    ]
+
+    with patch.object(client, "get_acts", return_value=acts) as mock_get:
+        csv_text = client.get_acts_csv(
+            test_date, date_end=test_date_end, title_contains=title_filter
+        )
+
+    assert "\"celex_uri\",\"act_number\",\"title\",\"date\"" in csv_text
+    mock_get.assert_called_once_with(
+        test_date, language="ENG", date_end=test_date_end, title_contains=title_filter
+    )

--- a/tests/doue/test_connector.py
+++ b/tests/doue/test_connector.py
@@ -1,4 +1,6 @@
 import pytest
+from unittest.mock import patch, MagicMock
+import requests
 
 from bulletin.doue.repository._connector import DoueConnector
 from bulletin.doue.exceptions import QueryError, EndpointError
@@ -43,6 +45,99 @@ def test_build_acts_query_unsupported_language(connector):
     """Test query building with unsupported language raises QueryError."""
     with pytest.raises(QueryError, match="Unsupported language: 'XYZ'"):
         connector.build_acts_query("2024-01-01", language="XYZ")
+
+
+def test_build_acts_query_date_range(connector):
+    query = connector.build_acts_query(date="2024-01-01", date_end="2024-01-31")
+    assert 'FILTER(?date >= "2024-01-01"^^xsd:date)' in query
+    assert 'FILTER(?date <= "2024-01-31"^^xsd:date)' in query
+
+
+def test_build_acts_query_title_contains(connector):
+    query = connector.build_acts_query(
+        date="2024-01-01", title_contains="regulation"
+    )
+    assert 'CONTAINS(LCASE(STR(?title)), LCASE("regulation"))' in query
+
+
+def test_build_acts_query_invalid_date_end_order(connector):
+    with pytest.raises(QueryError, match="date_end must be on or after date"):
+        connector.build_acts_query(date="2024-01-10", date_end="2024-01-01")
+
+
+def test_execute_query_http_error(connector):
+    """Test that execute_query raises EndpointError on HTTP error."""
+    query = "SELECT * WHERE { ?s ?p ?o } LIMIT 1"
+    
+    with patch("bulletin.doue.repository._connector.requests.post") as mock_post:
+        # Create a proper HTTPError with a response object
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        http_error = requests.exceptions.HTTPError("400 Client Error")
+        http_error.response = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+        mock_post.return_value = mock_response
+        
+        with pytest.raises(EndpointError) as exc_info:
+            connector.execute_query(query)
+        
+        assert exc_info.value.status_code == 400
+        assert "HTTP 400" in str(exc_info.value)
+
+
+def test_execute_query_connection_error(connector):
+    """Test that execute_query raises EndpointError on connection failure."""
+    query = "SELECT * WHERE { ?s ?p ?o } LIMIT 1"
+    
+    with patch("bulletin.doue.repository._connector.requests.post") as mock_post:
+        mock_post.side_effect = requests.exceptions.ConnectionError(
+            "Failed to connect"
+        )
+        
+        with pytest.raises(EndpointError) as exc_info:
+            connector.execute_query(query)
+        
+        assert exc_info.value.status_code is None
+        assert "Failed to reach SPARQL endpoint" in str(exc_info.value)
+
+
+def test_execute_query_timeout_error(connector):
+    """Test that execute_query raises EndpointError on timeout."""
+    query = "SELECT * WHERE { ?s ?p ?o } LIMIT 1"
+    
+    with patch("bulletin.doue.repository._connector.requests.post") as mock_post:
+        mock_post.side_effect = requests.exceptions.Timeout(
+            "Request timed out"
+        )
+        
+        with pytest.raises(EndpointError) as exc_info:
+            connector.execute_query(query)
+        
+        assert exc_info.value.status_code is None
+        assert "Failed to reach SPARQL endpoint" in str(exc_info.value)
+
+
+def test_execute_query_success(connector):
+    """Test that execute_query successfully returns parsed JSON response."""
+    query = "SELECT * WHERE { ?s ?p ?o } LIMIT 1"
+    expected_response = {
+        "head": {"vars": ["s", "p", "o"]},
+        "results": {"bindings": []}
+    }
+    
+    with patch("bulletin.doue.repository._connector.requests.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = expected_response
+        mock_post.return_value = mock_response
+        
+        result = connector.execute_query(query)
+        
+        assert result == expected_response
+        mock_post.assert_called_once()
+        # Verify the call was made with correct parameters
+        call_kwargs = mock_post.call_args[1]
+        assert call_kwargs["timeout"] == 30
+        assert call_kwargs["headers"]["Accept"] == "application/sparql-results+json"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
This pull request introduces several enhancements and API changes to improve the flexibility and usability of the bulletin-fetcher package, especially around querying and filtering official acts. The main updates include support for date ranges and title substring filters when fetching acts, updates to the public API and documentation, and new example scripts for both CLI and Jupyter notebook usage.

Key changes:

### API and Query Enhancements

* Extended the `DoueBulletinClient.get_acts` and `get_acts_csv` methods to accept optional `date_end` and `title_contains` parameters, allowing users to fetch acts within a date range and filter by title substring. This is supported by corresponding updates in the `DoueConnector.build_acts_query` method, which now validates and applies these filters to SPARQL queries. [[1]](diffhunk://#diff-1e65d9d95a5fe3dab6c90c4f89164e146308bdcd7d7e8e509b636c48981da27bL18-R48) [[2]](diffhunk://#diff-b3fdfa0d38575b28baee537263dcc695b947b216a4883be9ded63c4e6246b33fL20-R33) [[3]](diffhunk://#diff-b3fdfa0d38575b28baee537263dcc695b947b216a4883be9ded63c4e6246b33fL34-R53) [[4]](diffhunk://#diff-b3fdfa0d38575b28baee537263dcc695b947b216a4883be9ded63c4e6246b33fR66-R67) [[5]](diffhunk://#diff-b3fdfa0d38575b28baee537263dcc695b947b216a4883be9ded63c4e6246b33fL96-R116)

### Documentation and Usage Examples

* Updated the `README.md` and `docs/getting-started.md` to reflect the new API parameters and to simplify usage examples. Examples now show usage without requiring explicit language arguments and demonstrate the new filtering capabilities. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R59) [[3]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L28-R40)
* Added a Jupyter notebook example (`scripts/run_doue.ipynb`) demonstrating advanced usage, including date range and title filtering, and showing how to load results into a pandas DataFrame.

### CLI Script Improvements

* Refactored the `scripts/run_doue.py` script to use hardcoded example parameters for date range and title filtering, removing the previous command-line argument parsing for simplicity and consistency with the new API. [[1]](diffhunk://#diff-3005683d9f42f7dc1b92d673a36873a9c0fabfdf7f51279b714b2ef61589951cL3-L36) [[2]](diffhunk://#diff-3005683d9f42f7dc1b92d673a36873a9c0fabfdf7f51279b714b2ef61589951cL49-R38)

### Miscellaneous

* Minor improvements to documentation, such as adding a GitHub contact and cleaning up acknowledgements in `README.md`.
* Added missing imports and improved code clarity in the connector module.

These changes make the package more flexible for data analysis and integration workflows, and provide clearer, more modern usage examples.