### PR TITLE
feat: add method to fetch acts in JSON format and corresponding tests

### DIFF
--- a/scripts/run_eurlex.py
+++ b/scripts/run_eurlex.py
@@ -42,6 +42,11 @@ def main() -> int:
     print("CSV Output:")
     print(csv_output)
 
+    # Get data in JSON
+    json_output = client.get_acts_json(date=date, date_end=date_end, title_contains=title_contains, language=language) 
+    print("JSON Output:")
+    print(json_output)
+
     return 0
 
 

--- a/src/bulletin/eurlex/api/client.py
+++ b/src/bulletin/eurlex/api/client.py
@@ -4,7 +4,7 @@ High-level client for querying EU Official Journal (EUR-Lex) acts.
 from typing import Optional
 from ..repository._connector import EurlexConnector
 from ..constants import DEFAULT_LANGUAGE, SPARQL_ENDPOINT
-from ..converters import acts_to_csv, parse_acts_results, parse_category_types_results, parse_institution_types_results
+from ..converters import acts_to_csv, acts_to_json, parse_acts_results, parse_category_types_results, parse_institution_types_results
 from .models import EurlexOfficialAct, CategoryType, InstitutionType
 
 
@@ -51,6 +51,24 @@ class EurlexBulletinClient:
         """
         acts = self.get_acts(date, language=language, date_end=date_end, title_contains=title_contains, category_type=category_type, institution_type=institution_type)
         return acts_to_csv(acts)
+
+    def get_acts_json(self, date: str, date_end: Optional[str] = None, title_contains: Optional[str] = None, category_type: Optional[str] = None, institution_type: Optional[str] = None, language: str = DEFAULT_LANGUAGE) -> list[dict]:
+        """
+        Fetch Official Journal acts for a given date and return JSON output. Uses get_acts internally, so supports the same filters.
+
+        Args:
+            date: Publication date in ISO format (e.g. "2025-03-27").
+            date_end: End date in ISO format (e.g. "2025-03-27"). If provided, fetch acts published between `date` and `date_end` inclusive.
+            title_contains: Case-insensitive substring filter on title.
+            category_type: Filter by category type code (e.g. "RES" for Resolution, "ANNOUNC" for Announcement...). More types available at <http://publications.europa.eu/resource/authority/resource-type>. Optional.
+            institution_type: Filter by institution type code (e.g. "CONSIL" for Council of the European Union, "COM" for Commission...). More types available at <http://publications.europa.eu/resource/authority/corporate-body>. Optional.
+            language: ISO Language code (default: "ENG"). Supported values are defined in `LANGUAGE_CODE_MAP`. Examples: "ENG", "FRA", "DEU", "SPA"...
+        Returns:
+            A JSON string representing the acts.
+
+        """
+        acts = self.get_acts(date, language=language, date_end=date_end, title_contains=title_contains, category_type=category_type, institution_type=institution_type)
+        return acts_to_json(acts)    
 
     def get_category_types(self, language: str = DEFAULT_LANGUAGE) -> list[CategoryType]:
         """Fetch the list of possible category types from the authority list. This method may last a few minutes due to the size of the authority list.

--- a/src/bulletin/eurlex/converters.py
+++ b/src/bulletin/eurlex/converters.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
 import csv
+import json
 import io
 from typing import Any
 
@@ -49,6 +50,10 @@ def acts_to_csv(acts: list[EurlexOfficialAct]) -> str:
     for act in acts:
         writer.writerow(act._to_dict())
     return buffer.getvalue()
+
+def acts_to_json(acts: list[EurlexOfficialAct]) -> str:
+    """Serialize a list of acts to JSON format."""
+    return json.dumps([act._to_dict() for act in acts])
 
 
 def parse_category_types_results(results: Mapping[str, Any]) -> list[CategoryType]:

--- a/src/bulletin/eurlex/converters.py
+++ b/src/bulletin/eurlex/converters.py
@@ -51,9 +51,9 @@ def acts_to_csv(acts: list[EurlexOfficialAct]) -> str:
         writer.writerow(act._to_dict())
     return buffer.getvalue()
 
-def acts_to_json(acts: list[EurlexOfficialAct]) -> str:
+def acts_to_json(acts: list[EurlexOfficialAct]) -> list[dict]:
     """Serialize a list of acts to JSON format."""
-    return json.dumps([act._to_dict() for act in acts])
+    return [act._to_dict() for act in acts]
 
 
 def parse_category_types_results(results: Mapping[str, Any]) -> list[CategoryType]:

--- a/tests/eurlex/test_client.py
+++ b/tests/eurlex/test_client.py
@@ -332,15 +332,14 @@ class TestGetActsJson:
         ]
 
         with patch.object(client, "get_acts", return_value=acts) as mock_get:
-            json_text = client.get_acts_json(test_date)
+            json_list = client.get_acts_json(test_date)
 
-        data = json.loads(json_text)
 
-        assert len(data) == 1
-        assert data[0]["celex_uri"] == "https://example.com/act1"
-        assert data[0]["act_number"] == "2025/1"
-        assert data[0]["title"] == "Act 1"
-        assert data[0]["date"] == "2025-03-27"
+        assert len(json_list) == 1
+        assert json_list[0]["celex_uri"] == "https://example.com/act1"
+        assert json_list[0]["act_number"] == "2025/1"
+        assert json_list[0]["title"] == "Act 1"
+        assert json_list[0]["date"] == "2025-03-27"
         mock_get.assert_called_once_with(
             test_date,
             language="ENG",
@@ -354,9 +353,9 @@ class TestGetActsJson:
         test_date = "2025-03-27"
 
         with patch.object(client, "get_acts", return_value=[]) as mock_get:
-            json_text = client.get_acts_json(test_date)
+            json_list = client.get_acts_json(test_date)
 
-        assert json_text == "[]"
+        assert json_list == []
         mock_get.assert_called_once_with(
             test_date,
             language="ENG",
@@ -389,16 +388,14 @@ class TestGetActsJson:
         ]
 
         with patch.object(client, "get_acts", return_value=acts) as mock_get:
-            json_text = client.get_acts_json(
+            json_list = client.get_acts_json(
                 test_date, date_end=test_date_end, title_contains=title_filter
             )
 
-        data = json.loads(json_text)
-
-        assert len(data) == 1
-        assert data[0]["celex_uri"] == "https://example.com/act1"
-        assert data[0]["act_number"] == "2025/1"
-        assert data[0]["title"] == "Regulation about X"
+        assert len(json_list) == 1
+        assert json_list[0]["celex_uri"] == "https://example.com/act1"
+        assert json_list[0]["act_number"] == "2025/1"
+        assert json_list[0]["title"] == "Regulation about X"
 
         mock_get.assert_called_once_with(
             test_date, language="ENG", date_end=test_date_end, title_contains=title_filter, category_type=None, institution_type=None

--- a/tests/eurlex/test_client.py
+++ b/tests/eurlex/test_client.py
@@ -1,6 +1,7 @@
 """Unit tests for EurlexBulletinClient."""
 
 from datetime import date
+import json
 from unittest.mock import patch
 
 import pytest
@@ -306,6 +307,114 @@ class TestGetActsCsv:
             test_date, language="ENG", date_end=None, title_contains=None, category_type="RES", institution_type=None
         )
 
+
+class TestGetActsJson:
+    """Tests for get_acts_json method."""
+
+    def test_returns_json(self, client) -> None:
+        """Test get_acts_json returns JSON text."""
+        test_date = "2025-03-27"
+        acts = [
+            EurlexOfficialAct(
+                celex_uri="https://example.com/act1",
+                act_number="2025/1",
+                title="Act 1",
+                date=date(2025, 3, 27),
+                section_code=None,
+                subsection_code=None,
+                category_code=None,
+                category_uri=None,
+                category_label=None,
+                institution_code=None,
+                institution_uri=None,
+                institution_label=None,
+            )
+        ]
+
+        with patch.object(client, "get_acts", return_value=acts) as mock_get:
+            json_text = client.get_acts_json(test_date)
+
+        data = json.loads(json_text)
+
+        assert len(data) == 1
+        assert data[0]["celex_uri"] == "https://example.com/act1"
+        assert data[0]["act_number"] == "2025/1"
+        assert data[0]["title"] == "Act 1"
+        assert data[0]["date"] == "2025-03-27"
+        mock_get.assert_called_once_with(
+            test_date,
+            language="ENG",
+            date_end=None,
+            title_contains=None,
+            category_type=None,
+            institution_type=None,
+        )
+
+    def test_returns_empty_json(self, client) -> None:
+        test_date = "2025-03-27"
+
+        with patch.object(client, "get_acts", return_value=[]) as mock_get:
+            json_text = client.get_acts_json(test_date)
+
+        assert json_text == "[]"
+        mock_get.assert_called_once_with(
+            test_date,
+            language="ENG",
+            date_end=None,
+            title_contains=None,
+            category_type=None,
+            institution_type=None,
+        )
+
+    def test_with_date_end_and_title_contains(self, client) -> None:
+        """Test get_acts_json with date_end and title_contains parameters."""
+        test_date = "2025-03-27"
+        test_date_end = "2025-03-31"
+        title_filter = "regulation"
+        acts = [
+            EurlexOfficialAct(
+                celex_uri="https://example.com/act1",
+                act_number="2025/1",
+                title="Regulation about X",
+                date=date(2025, 3, 27),
+                section_code=None,
+                subsection_code=None,
+                category_code=None,
+                category_uri=None,
+                category_label=None,
+                institution_code=None,
+                institution_uri=None,
+                institution_label=None,
+            )
+        ]
+
+        with patch.object(client, "get_acts", return_value=acts) as mock_get:
+            json_text = client.get_acts_json(
+                test_date, date_end=test_date_end, title_contains=title_filter
+            )
+
+        data = json.loads(json_text)
+
+        assert len(data) == 1
+        assert data[0]["celex_uri"] == "https://example.com/act1"
+        assert data[0]["act_number"] == "2025/1"
+        assert data[0]["title"] == "Regulation about X"
+
+        mock_get.assert_called_once_with(
+            test_date, language="ENG", date_end=test_date_end, title_contains=title_filter, category_type=None, institution_type=None
+        )
+
+    def test_with_category_type(self, client):
+        """Test get_acts_json with category_type parameter."""
+        test_date = "2025-03-27"
+        category_type = "RES"
+        
+        with patch.object(client, "get_acts", return_value=[]) as mock_get:
+            client.get_acts_json(test_date, category_type=category_type)
+
+        mock_get.assert_called_once_with(
+            test_date, language="ENG", date_end=None, title_contains=None, category_type="RES", institution_type=None
+        )
 
 class TestGetCategoryTypes:
     """Tests for get_category_types method."""

--- a/tests/eurlex/test_converters.py
+++ b/tests/eurlex/test_converters.py
@@ -173,19 +173,18 @@ class TestActsToJson:
             )
         ]
 
-        json_text = acts_to_json(acts)
-        data = json.loads(json_text)
+        json_list = acts_to_json(acts)
 
-        assert isinstance(data, list)
-        assert len(data) == 1
-        assert data[0]["celex_uri"] == "https://example.com/act1"
-        assert data[0]["act_number"] == "2025/1"
-        assert data[0]["title"] == "Act 1"
-        assert data[0]["date"] == "2025-03-27"
-        assert data[0]["section_code"] is None
+        assert isinstance(json_list, list)
+        assert len(json_list) == 1
+        assert json_list[0]["celex_uri"] == "https://example.com/act1"
+        assert json_list[0]["act_number"] == "2025/1"
+        assert json_list[0]["title"] == "Act 1"
+        assert json_list[0]["date"] == "2025-03-27"
+        assert json_list[0]["section_code"] is None
 
     def test_serializes_empty_list(self) -> None:
-        assert acts_to_json([]) == "[]"
+        assert acts_to_json([]) == []
 
 
 class TestParseCategoryTypesResults:

--- a/tests/eurlex/test_converters.py
+++ b/tests/eurlex/test_converters.py
@@ -1,10 +1,11 @@
 """Unit tests for converters utilities."""
 
 from datetime import date
+import json
 
 import pytest
 
-from bulletin.eurlex.converters import acts_to_csv, parse_acts_results, parse_category_types_results, parse_institution_types_results
+from bulletin.eurlex.converters import acts_to_csv, acts_to_json, parse_acts_results, parse_category_types_results, parse_institution_types_results
 from bulletin.eurlex.api.models import EurlexOfficialAct, CategoryType, InstitutionType
 
 
@@ -150,6 +151,41 @@ class TestActsToCsv:
         assert rows[1].startswith(
             "\"https://example.com/act1\",\"2025/1\",\"Act 1\",\"2025-03-27\""
         )
+
+class TestActsToJson:
+    """Tests for acts_to_json converter."""
+
+    def test_serializes_rows(self) -> None:
+        acts = [
+            EurlexOfficialAct(
+                celex_uri="https://example.com/act1",
+                act_number="2025/1",
+                title="Act 1",
+                date=date(2025, 3, 27),
+                section_code=None,
+                subsection_code=None,
+                category_code=None,
+                category_uri=None,
+                category_label=None,
+                institution_code=None,
+                institution_uri=None,
+                institution_label=None,
+            )
+        ]
+
+        json_text = acts_to_json(acts)
+        data = json.loads(json_text)
+
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["celex_uri"] == "https://example.com/act1"
+        assert data[0]["act_number"] == "2025/1"
+        assert data[0]["title"] == "Act 1"
+        assert data[0]["date"] == "2025-03-27"
+        assert data[0]["section_code"] is None
+
+    def test_serializes_empty_list(self) -> None:
+        assert acts_to_json([]) == "[]"
 
 
 class TestParseCategoryTypesResults:


### PR DESCRIPTION
This pull request adds support for exporting Official Journal acts data in JSON format, alongside the existing CSV export functionality. It introduces a new `get_acts_json` method to the client, a corresponding `acts_to_json` converter, and comprehensive unit tests to ensure correct behavior. The main script is also updated to demonstrate the new JSON output.

**New JSON Export Functionality:**

* Added a new `acts_to_json` function in `converters.py` to serialize a list of `EurlexOfficialAct` objects to JSON format.
* Introduced the `get_acts_json` method in `EurlexBulletinClient` to provide JSON output for acts, supporting the same filters as the CSV method.
* Updated imports to include the new converter.

**Testing Enhancements:**

* Added unit tests for `acts_to_json` in `test_converters.py` to verify correct serialization and handling of empty lists.
* Added a comprehensive test class for `get_acts_json` in `test_client.py`, covering various parameter combinations and ensuring correct delegation to the underlying `get_acts` method.

**Script and Utility Updates:**

* Updated the main script (`run_eurlex.py`) to demonstrate and print the new JSON output feature.
* Added necessary imports for JSON handling in both the client and test files. [[1]](diffhunk://#diff-6052173d911be7abe359280bf5899877c3d24cb220e821af168e9618afb70c55R3) [[2]](diffhunk://#diff-7ef2236a3d0570947628eb816bf8f890bcc245480a25ac15eb241c237ce10e8cR4) [[3]](diffhunk://#diff-527f377d0e9943ae27744a78fbb6744642a48e8fec166205de25581aeacb904dR4-R8)