### PR TITLE
Feature/find act by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ EU legal acts can be queried through public semantic web infrastructure, but usi
 
 - Search EU legal acts from the Official Journal of the European Union.
 - Filter acts by date or date range, act type, publishing institution, text contained in the act title, language.
+- Fetch the content stream of an act by CELEX id or by the URI returned in search results.
 - Retrieve available act types and publishing institutions.
 - Return act search results as Python objects, JSON-compatible dictionaries, XML, CSV or pandas DataFrames.
 - Work with Python instead of raw SPARQL queries.
@@ -71,6 +72,7 @@ acts = client.get_acts(
     language="ENG"
 )
 
+# CSV output
 acts_csv = client.get_acts(
     date="2025-01-01",
     date_end="2025-03-31",
@@ -79,27 +81,23 @@ acts_csv = client.get_acts(
     output_format="csv",
 )
 
-acts_xml = client.get_acts(
-    date="2025-01-01",
-    date_end="2025-03-31",
-    title_contains="artificial intelligence",
-    language="ENG",
-    output_format="xml",
-)
-
-acts_df = client.get_acts(
-    date="2025-01-01",
-    date_end="2025-03-31",
-    title_contains="artificial intelligence",
-    language="ENG",
-    output_format="df",
-)
-
 print(f"Total acts: {len(acts)}")
 if acts:
     first = acts[0]
     print(first.celex_uri)
     print(first.title)
+
+    first_content = client.get_act_content(
+        first.celex_uri,
+        language="ENG",
+    )
+    print(first_content[:500])
+
+    content_from_celex_id = client.get_act_content(
+        "52025M12135",
+        language="ENG",
+    )
+    print(content_from_celex_id[:500])
 ```
 
 ### Example scripts

--- a/docs/api/eurlex.md
+++ b/docs/api/eurlex.md
@@ -3,8 +3,9 @@
 EUR-Lex support is split into two layers:
 
 - API layer: high-level client and typed parsing models.
-- Repository layer: connector for query construction and endpoint communication.
+- Repository layer: connector for SPARQL query construction, endpoint communication and Cellar publication content retrieval.
 - [Official SPARQL Query Editor](https://publications.europa.eu/webapi/rdf/sparql)
+- [Official Cellar publication REST API](https://op.europa.eu/en/web/cellar/cellar-data/publications)
 
 ## Basic Imports
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,6 +67,18 @@ if acts:
     first = acts[0]
     print(first.celex_uri)
     print(first.title)
+
+    first_content = client.get_act_content(
+        first.celex_uri,
+        language="ENG",
+    )
+    print(first_content[:500])
+
+    content_from_celex_id = client.get_act_content(
+        "52025M12135",
+        language="ENG",
+    )
+    print(content_from_celex_id[:500])
 ```
 
 ### Run Example Scripts

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ EU legal acts can be queried through public semantic web infrastructure, but usi
 
 - Search EU legal acts from the Official Journal of the European Union.
 - Filter acts by date or date range, act type, publishing institution, text contained in the act title, language.
+- Fetch the content stream of an act by CELEX id or by the URI returned in search results.
 - Retrieve available act types and publishing institutions.
 - Return act search results as Python objects, JSON-compatible dictionaries, XML, CSV or pandas DataFrames.
 - Work with Python instead of raw SPARQL queries.

--- a/scripts/run_eurlex.py
+++ b/scripts/run_eurlex.py
@@ -12,8 +12,8 @@ def main() -> int:
     date = "2025-01-01"
     date_end = "2026-03-31"
     title_contains = "science"
-    category_type="ANNOUNC"
-    institution_type="COM"
+    category_type = "ANNOUNC"
+    institution_type = "COM"
     language = "ENG"
     # Examples of filtering:
     # - Pass category_type="ANNOUNC" to filter by category type (e.g., announcements)
@@ -47,6 +47,23 @@ def main() -> int:
     print(f"Total acts: {len(acts)}")
     print("Done.")
 
+    if acts:
+        first_act = acts[0]
+        print("\n" + "=" * 60 + "\n")
+        print("Fetching content for the first act:")
+        print(first_act.celex_uri)
+
+        try:
+            content = client.get_act_content(
+                first_act.celex_uri,
+                language=language,
+                max_size=500_000,
+            )
+        except Exception as exc:
+            print(f"Error while fetching act content: {exc}", file=sys.stderr)
+        else:
+            print(content)
+
     print("\n" + "=" * 60 + "\n")
 
     formats = ["objects", "json", "csv", "xml", "df"]
@@ -64,7 +81,6 @@ def main() -> int:
         )
         print(output)
         print("-" * 60)
-
 
     return 0
 

--- a/scripts/run_eurlex.py
+++ b/scripts/run_eurlex.py
@@ -10,8 +10,10 @@ def main() -> int:
     client = EurlexBulletinClient()
 
     date = "2025-01-01"
-    date_end = "2025-03-31"
-    title_contains = "artificial intelligence"
+    date_end = "2026-03-31"
+    title_contains = "science"
+    category_type="ANNOUNC"
+    institution_type="COM"
     language = "ENG"
     # Examples of filtering:
     # - Pass category_type="ANNOUNC" to filter by category type (e.g., announcements)
@@ -20,11 +22,11 @@ def main() -> int:
     try:
         acts = client.get_acts(
             date=date,
-            language=language,
             date_end=date_end,
+            language=language,
             title_contains=title_contains,
-            category_type=None,
-            institution_type=None,
+            category_type=category_type,
+            institution_type=institution_type,
         )
     except Exception as exc:
         print(f"Error while fetching acts: {exc}", file=sys.stderr)
@@ -47,49 +49,22 @@ def main() -> int:
 
     print("\n" + "=" * 60 + "\n")
 
-    # Get data in CSV
-    csv_output = client.get_acts(
-        date=date,
-        date_end=date_end,
-        title_contains=title_contains,
-        language=language,
-        output_format="csv",
-    )
-    print("CSV Output:")
-    print(csv_output)
+    formats = ["objects", "json", "csv", "xml", "df"]
 
-    # Get data in XML
-    xml_output = client.get_acts(
-        date=date,
-        date_end=date_end,
-        title_contains=title_contains,
-        language=language,
-        output_format="xml",
-    )
-    print("XML Output:")
-    print(xml_output)
+    for fmt in formats:
+        print(f"Testing output format: {fmt}")
+        output = client.get_acts(
+            date=date,
+            date_end=date_end,
+            title_contains=title_contains,
+            language=language,
+            category_type=category_type,
+            institution_type=institution_type,
+            output_format=fmt,
+        )
+        print(output)
+        print("-" * 60)
 
-    # Get data in JSON
-    json_output = client.get_acts(
-        date=date,
-        date_end=date_end,
-        title_contains=title_contains,
-        language=language,
-        output_format="json",
-    )
-    print("JSON Output:")
-    print(json_output)
-
-    # Get data in pandas DataFrame format
-    dataframe_output = client.get_acts(
-        date=date,
-        date_end=date_end,
-        title_contains=title_contains,
-        language=language,
-        output_format="df",
-    )
-    print("DataFrame Output:")
-    print(dataframe_output.head())
 
     return 0
 

--- a/scripts/run_eurlex.py
+++ b/scripts/run_eurlex.py
@@ -55,7 +55,7 @@ def main() -> int:
 
         try:
             content = client.get_act_content(
-                first_act.celex_uri,
+                "52025M12135",
                 language=language,
                 max_size=500_000,
             )

--- a/scripts/use_cases/case_1_ai_evolution.ipynb
+++ b/scripts/use_cases/case_1_ai_evolution.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -57,6 +57,17 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "ename": "",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. \n",
+      "\u001b[1;31mPlease review the code in the cell(s) to identify a possible cause of the failure. \n",
+      "\u001b[1;31mClick <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. \n",
+      "\u001b[1;31mView Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
+     ]
     }
    ],
    "source": [
@@ -98,7 +109,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/src/bulletin/eurlex/api/client.py
+++ b/src/bulletin/eurlex/api/client.py
@@ -112,6 +112,37 @@ class EurlexBulletinClient:
         acts = parse_acts_results(response)
         return _format_acts(acts, normalized_output_format)
 
+    def get_act_content(
+        self,
+        act_id_or_uri: str,
+        language: str = DEFAULT_LANGUAGE,
+        max_size: Optional[int] = None,
+        return_bytes: bool = False,
+    ) -> Union[str, bytes]:
+        """Fetch the publication content stream for an act.
+
+        Pass either a CELEX id (for example "52025M12135") or the full URI
+        returned by `EurlexOfficialAct.celex_uri`.
+
+        Args:
+            act_id_or_uri: CELEX id or full resource URI. This is not the
+                Official Journal act number.
+            language: ISO 639-3 language code (default: "ENG").
+            max_size: Optional maximum content-stream size in bytes.
+            return_bytes: Return raw response bytes instead of decoded text.
+
+        Returns:
+            The publication content decoded as html text, or bytes when return_bytes
+            is True.
+        """
+        resource_uri = self._connector.build_act_content_url(act_id_or_uri)
+        return self._connector.fetch_publication_content(
+            resource_uri,
+            language=language,
+            max_size=max_size,
+            return_bytes=return_bytes,
+        )
+
     def get_category_types(
         self, language: str = DEFAULT_LANGUAGE
     ) -> list[CategoryType]:

--- a/src/bulletin/eurlex/constants.py
+++ b/src/bulletin/eurlex/constants.py
@@ -24,7 +24,7 @@ LANGUAGE_CODE_MAP = {
     "ELL": "el",
     "EST": "et",
     "FIN": "fi",
-    "GAE": "ga",
+    "GLE": "ga",
     "HRV": "hr",
     "HUN": "hu",
     "LIT": "lt",

--- a/src/bulletin/eurlex/repository/_connector.py
+++ b/src/bulletin/eurlex/repository/_connector.py
@@ -231,7 +231,7 @@ class EurlexConnector:
         if identifier.startswith(("http://", "https://")):
             return identifier
 
-        return f"http://{CELLAR_DOMAIN}/resource/celex/{quote(identifier, safe='')}"
+        return f"https://{CELLAR_DOMAIN}/resource/celex/{quote(identifier, safe='')}"
 
     def fetch_publication_content(
         self,

--- a/src/bulletin/eurlex/repository/_connector.py
+++ b/src/bulletin/eurlex/repository/_connector.py
@@ -1,19 +1,27 @@
-"""
-Connector for the EUR-Lex / Cellar SPARQL endpoint.
+"""Connector for the EUR-Lex / Cellar SPARQL endpoint and Cellar REST API.
 
 Handles query building and HTTP communication.
 """
 
+from __future__ import annotations
+
 from datetime import date
-from typing import Optional
+from typing import Optional, Union
+from urllib.parse import quote
+
 import requests  # type: ignore
 
-from ..constants import SPARQL_ENDPOINT, LANGUAGE_CODE_MAP, DEFAULT_LANGUAGE, CELLAR_DOMAIN
+from ..constants import (
+    SPARQL_ENDPOINT,
+    LANGUAGE_CODE_MAP,
+    DEFAULT_LANGUAGE,
+    CELLAR_DOMAIN,
+)
 from ..exceptions import EndpointError, QueryError
 
 
 class EurlexConnector:
-    """Connector class for the EUR-Lex / Cellar SPARQL endpoint."""
+    """Connector class for the EUR-Lex / Cellar SPARQL endpoint and REST API."""
 
     def __init__(self, endpoint: str = SPARQL_ENDPOINT, timeout: int = 300):
         self.endpoint = endpoint
@@ -56,7 +64,7 @@ class EurlexConnector:
             title_contains = title_contains.strip()
             if not title_contains:
                 raise QueryError("title_contains filter cannot be empty.")
-            
+
         if category_type is not None:
             category_type = category_type.strip()
             if not category_type:
@@ -74,11 +82,11 @@ class EurlexConnector:
                 f"Supported: {', '.join(sorted(LANGUAGE_CODE_MAP))}"
             )
 
-        language_uri = (
-            f"http://{CELLAR_DOMAIN}/resource/authority/language/{language}"
-        )
+        language_uri = f"http://{CELLAR_DOMAIN}/resource/authority/language/{language}"
 
-        filters: list[str] = self._get_act_filters(date, date_end, title_contains, category_type, institution_type)
+        filters: list[str] = self._get_act_filters(
+            date, date_end, title_contains, category_type, institution_type
+        )
 
         query_template = """
             PREFIX cdm: <http://{cellar_domain}/ontology/cdm#>
@@ -151,7 +159,7 @@ class EurlexConnector:
             The SPARQL query string.
         """
         lang_code = LANGUAGE_CODE_MAP.get(language, "en")
-        
+
         query = f"""
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             PREFIX at: <http://{CELLAR_DOMAIN}/ontology/authority/>
@@ -170,7 +178,7 @@ class EurlexConnector:
             ORDER BY ?code
         """
         return query
-    
+
     def build_institution_types_query(self, language: str = DEFAULT_LANGUAGE) -> str:
         """Build a SPARQL query to fetch the list of institutions.
 
@@ -184,7 +192,7 @@ class EurlexConnector:
             The SPARQL query string.
         """
         lang_code = LANGUAGE_CODE_MAP.get(language, "en")
-        
+
         query = f"""
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             PREFIX at: <http://{CELLAR_DOMAIN}/ontology/authority/>
@@ -203,6 +211,92 @@ class EurlexConnector:
             ORDER BY ?code
         """
         return query
+
+    def build_act_content_url(self, act_id_or_uri: str) -> str:
+        """Build a Cellar publication URL from a CELEX id or resource URI.
+
+        Args:
+            act_id_or_uri: CELEX id (e.g. "32014R0001") or full Cellar resource URI.
+
+        Returns:
+            A resource URI usable with Cellar's publication REST API.
+
+        Raises:
+            QueryError: If act_id_or_uri is empty.
+        """
+        identifier = act_id_or_uri.strip()
+        if not identifier:
+            raise QueryError("act_id_or_uri cannot be empty.")
+
+        if identifier.startswith(("http://", "https://")):
+            return identifier
+
+        return f"http://{CELLAR_DOMAIN}/resource/celex/{quote(identifier, safe='')}"
+
+    def fetch_publication_content(
+        self,
+        resource_uri: str,
+        language: str = DEFAULT_LANGUAGE,
+        max_size: Optional[int] = None,
+        return_bytes: bool = False,
+    ) -> Union[str, bytes]:
+        """Fetch publication content from EU API.
+
+        Args:
+            resource_uri: Full Cellar resource URI.
+            language: ISO 639-3 language code used by Cellar (e.g. "ENG").
+            max_size: Optional maximum content-stream size in bytes.
+            return_bytes: Return raw response bytes instead of decoded text.
+
+        Returns:
+            The response body decoded as text, or raw bytes when return_bytes is True.
+
+        Raises:
+            QueryError: If language, resource_uri, or max_size are invalid.
+            EndpointError: If the request fails or Cellar is unreachable.
+        """
+        if not resource_uri.strip():
+            raise QueryError("resource_uri cannot be empty.")
+
+        language = language.strip().upper()
+        if LANGUAGE_CODE_MAP.get(language) is None:
+            raise QueryError(
+                f"Unsupported language: '{language}'. "
+                f"Supported: {', '.join(sorted(LANGUAGE_CODE_MAP))}"
+            )
+
+        headers = {
+            "Accept": "application/xhtml+xml",
+            "Accept-Language": language.lower(),
+        }
+
+        if max_size is not None:
+            if max_size <= 0:
+                raise QueryError("max_size must be a positive integer.")
+            headers["Accept-Max-Cs-Size"] = str(max_size)
+
+        try:
+            response = requests.get(
+                resource_uri,
+                timeout=self.timeout,
+                headers=headers,
+                allow_redirects=True,
+            )
+            response.raise_for_status()
+            if return_bytes:
+                return response.content
+            return response.text
+        except requests.exceptions.HTTPError as e:
+            raise EndpointError(
+                f"EU API returned HTTP {e.response.status_code}",
+                status_code=e.response.status_code,
+                endpoint=resource_uri,
+            ) from e
+        except requests.exceptions.RequestException as e:
+            raise EndpointError(
+                f"Failed to reach EU API: {e}",
+                endpoint=resource_uri,
+            ) from e
 
     def execute_query(self, query: str) -> dict:
         """Send a SPARQL query to the endpoint and return the JSON response.
@@ -224,7 +318,7 @@ class EurlexConnector:
                 headers={"Accept": "application/sparql-results+json"},
             )
             response.raise_for_status()
-            return response.json() # type: ignore
+            return response.json()  # type: ignore
         except requests.exceptions.HTTPError as e:
             raise EndpointError(
                 f"SPARQL endpoint returned HTTP {e.response.status_code}",
@@ -237,7 +331,14 @@ class EurlexConnector:
                 endpoint=self.endpoint,
             ) from e
 
-    def _get_act_filters(self, date: str, date_end: Optional[str] = None, title_contains: Optional[str] = None, category_type: Optional[str] = None, institution_type: Optional[str] = None) -> list[str]:
+    def _get_act_filters(
+        self,
+        date: str,
+        date_end: Optional[str] = None,
+        title_contains: Optional[str] = None,
+        category_type: Optional[str] = None,
+        institution_type: Optional[str] = None,
+    ) -> list[str]:
         filters: list[str] = []
         if date_end is not None:
             filters.append(f'FILTER(?date >= "{date}"^^xsd:date)')
@@ -272,7 +373,9 @@ def _parse_date(value: str) -> date:
     try:
         return date.fromisoformat(value)
     except ValueError as exc:
-        raise QueryError(f"Invalid date format: '{value}'. Expected YYYY-MM-DD.") from exc
+        raise QueryError(
+            f"Invalid date format: '{value}'. Expected YYYY-MM-DD."
+        ) from exc
 
 
 def _escape_sparql_literal(value: str) -> str:

--- a/tests/eurlex/test_client.py
+++ b/tests/eurlex/test_client.py
@@ -542,6 +542,70 @@ class TestGetActsOutputFormat:
         assert not hasattr(EurlexBulletinClient, "get_acts_json")
 
 
+class TestGetActContent:
+    """Tests for get_act_content method."""
+
+    def test_fetches_content_from_celex_id(self, client, mock_connector):
+        """Test fetching act content from a CELEX id."""
+        mock_instance = mock_connector.return_value
+        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+        mock_instance.build_act_content_url.return_value = resource_uri
+        mock_instance.fetch_publication_content.return_value = "<html>content</html>"
+
+        result = client.get_act_content(
+            "52025M12135",
+            language="ENG",
+            max_size=4096,
+        )
+
+        assert result == "<html>content</html>"
+        mock_instance.build_act_content_url.assert_called_once_with("52025M12135")
+        mock_instance.fetch_publication_content.assert_called_once_with(
+            resource_uri,
+            language="ENG",
+            max_size=4096,
+            return_bytes=False,
+        )
+
+    def test_fetches_content_from_uri(self, client, mock_connector):
+        """Test fetching act content from the URI returned by get_acts."""
+        mock_instance = mock_connector.return_value
+        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+        mock_instance.build_act_content_url.return_value = resource_uri
+        mock_instance.fetch_publication_content.return_value = "<html>content</html>"
+
+        result = client.get_act_content(resource_uri)
+
+        assert result == "<html>content</html>"
+        mock_instance.build_act_content_url.assert_called_once_with(resource_uri)
+        mock_instance.fetch_publication_content.assert_called_once_with(
+            resource_uri,
+            language="ENG",
+            max_size=None,
+            return_bytes=False,
+        )
+
+    def test_fetches_binary_content(self, client, mock_connector):
+        """Test fetching binary act content such as PDFs."""
+        mock_instance = mock_connector.return_value
+        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+        mock_instance.build_act_content_url.return_value = resource_uri
+        mock_instance.fetch_publication_content.return_value = b"%PDF-1.7"
+
+        result = client.get_act_content(
+            "52025M12135",
+            return_bytes=True,
+        )
+
+        assert result == b"%PDF-1.7"
+        mock_instance.fetch_publication_content.assert_called_once_with(
+            resource_uri,
+            language="ENG",
+            max_size=None,
+            return_bytes=True,
+        )
+
+
 class TestGetCategoryTypes:
     """Tests for get_category_types method."""
 

--- a/tests/eurlex/test_connector.py
+++ b/tests/eurlex/test_connector.py
@@ -99,19 +99,19 @@ class TestBuildActContentUrl:
 
     def test_celex_id(self, connector):
         url = connector.build_act_content_url("52025M12135")
-        assert url == "http://publications.europa.eu/resource/celex/52025M12135"
+        assert url == "https://publications.europa.eu/resource/celex/52025M12135"
 
     def test_full_resource_uri(self, connector):
-        uri = "http://publications.europa.eu/resource/celex/52025M12135"
+        uri = "https://publications.europa.eu/resource/celex/52025M12135"
         assert connector.build_act_content_url(uri) == uri
 
     def test_strips_identifier(self, connector):
         url = connector.build_act_content_url("  52025M12135  ")
-        assert url == "http://publications.europa.eu/resource/celex/52025M12135"
+        assert url == "https://publications.europa.eu/resource/celex/52025M12135"
 
     def test_url_encodes_celex_id(self, connector):
         url = connector.build_act_content_url("OJ 2025/1")
-        assert url == "http://publications.europa.eu/resource/celex/OJ%202025%2F1"
+        assert url == "https://publications.europa.eu/resource/celex/OJ%202025%2F1"
 
     def test_empty_identifier(self, connector):
         with pytest.raises(QueryError, match="act_id_or_uri cannot be empty"):
@@ -122,7 +122,7 @@ class TestFetchPublicationContent:
     """Tests for fetch_publication_content method."""
 
     def test_success_text(self, connector):
-        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+        resource_uri = "https://publications.europa.eu/resource/celex/52025M12135"
         expected_content = "<html><body>Act content</body></html>"
 
         with patch("bulletin.eurlex.repository._connector.requests.get") as mock_get:
@@ -150,7 +150,7 @@ class TestFetchPublicationContent:
         mock_response.raise_for_status.assert_called_once_with()
 
     def test_success_bytes(self, connector):
-        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+        resource_uri = "https://publications.europa.eu/resource/celex/52025M12135"
         expected_content = b"%PDF-1.7"
 
         with patch("bulletin.eurlex.repository._connector.requests.get") as mock_get:
@@ -166,7 +166,7 @@ class TestFetchPublicationContent:
         assert result == expected_content
 
     def test_lowercase_language_is_normalized(self, connector):
-        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+        resource_uri = "https://publications.europa.eu/resource/celex/52025M12135"
 
         with patch("bulletin.eurlex.repository._connector.requests.get") as mock_get:
             mock_response = MagicMock()
@@ -181,7 +181,7 @@ class TestFetchPublicationContent:
     def test_unsupported_language(self, connector):
         with pytest.raises(QueryError, match="Unsupported language: 'XYZ'"):
             connector.fetch_publication_content(
-                "http://publications.europa.eu/resource/celex/52025M12135",
+                "https://publications.europa.eu/resource/celex/52025M12135",
                 language="XYZ",
             )
 
@@ -192,12 +192,12 @@ class TestFetchPublicationContent:
     def test_invalid_max_size(self, connector):
         with pytest.raises(QueryError, match="max_size must be a positive integer"):
             connector.fetch_publication_content(
-                "http://publications.europa.eu/resource/celex/52025M12135",
+                "https://publications.europa.eu/resource/celex/52025M12135",
                 max_size=0,
             )
 
     def test_http_error(self, connector):
-        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+        resource_uri = "https://publications.europa.eu/resource/celex/52025M12135"
 
         with patch("bulletin.eurlex.repository._connector.requests.get") as mock_get:
             mock_response = MagicMock()
@@ -215,7 +215,7 @@ class TestFetchPublicationContent:
         assert "HTTP 404" in str(exc_info.value)
 
     def test_connection_error(self, connector):
-        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+        resource_uri = "https://publications.europa.eu/resource/celex/52025M12135"
 
         with patch("bulletin.eurlex.repository._connector.requests.get") as mock_get:
             mock_get.side_effect = requests.exceptions.ConnectionError("Failed")
@@ -225,7 +225,7 @@ class TestFetchPublicationContent:
 
         assert exc_info.value.status_code is None
         assert exc_info.value.endpoint == resource_uri
-        assert "Failed to reach Cellar REST API" in str(exc_info.value)
+        assert "Failed to reach EU API" in str(exc_info.value)
 
 
 class TestExecuteQuery:

--- a/tests/eurlex/test_connector.py
+++ b/tests/eurlex/test_connector.py
@@ -47,7 +47,9 @@ class TestBuildActsQuery:
         assert 'FILTER(?date <= "2024-01-31"^^xsd:date)' in query
 
     def test_title_contains(self, connector):
-        query = connector.build_acts_query(date="2024-01-01", title_contains="regulation")
+        query = connector.build_acts_query(
+            date="2024-01-01", title_contains="regulation"
+        )
         assert 'CONTAINS(LCASE(STR(?title)), LCASE("regulation"))' in query
 
     def test_category_type(self, connector):
@@ -92,6 +94,140 @@ class TestBuildInstitutionTypesQuery:
         assert 'FILTER(LANG(?label) = "es")' in query
 
 
+class TestBuildActContentUrl:
+    """Tests for build_act_content_url method."""
+
+    def test_celex_id(self, connector):
+        url = connector.build_act_content_url("52025M12135")
+        assert url == "http://publications.europa.eu/resource/celex/52025M12135"
+
+    def test_full_resource_uri(self, connector):
+        uri = "http://publications.europa.eu/resource/celex/52025M12135"
+        assert connector.build_act_content_url(uri) == uri
+
+    def test_strips_identifier(self, connector):
+        url = connector.build_act_content_url("  52025M12135  ")
+        assert url == "http://publications.europa.eu/resource/celex/52025M12135"
+
+    def test_url_encodes_celex_id(self, connector):
+        url = connector.build_act_content_url("OJ 2025/1")
+        assert url == "http://publications.europa.eu/resource/celex/OJ%202025%2F1"
+
+    def test_empty_identifier(self, connector):
+        with pytest.raises(QueryError, match="act_id_or_uri cannot be empty"):
+            connector.build_act_content_url("   ")
+
+
+class TestFetchPublicationContent:
+    """Tests for fetch_publication_content method."""
+
+    def test_success_text(self, connector):
+        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+        expected_content = "<html><body>Act content</body></html>"
+
+        with patch("bulletin.eurlex.repository._connector.requests.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.text = expected_content
+            mock_get.return_value = mock_response
+
+            result = connector.fetch_publication_content(
+                resource_uri,
+                language="ENG",
+                max_size=2048,
+            )
+
+        assert result == expected_content
+        mock_get.assert_called_once_with(
+            resource_uri,
+            timeout=300,
+            headers={
+                "Accept": "application/xhtml+xml",
+                "Accept-Language": "eng",
+                "Accept-Max-Cs-Size": "2048",
+            },
+            allow_redirects=True,
+        )
+        mock_response.raise_for_status.assert_called_once_with()
+
+    def test_success_bytes(self, connector):
+        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+        expected_content = b"%PDF-1.7"
+
+        with patch("bulletin.eurlex.repository._connector.requests.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.content = expected_content
+            mock_get.return_value = mock_response
+
+            result = connector.fetch_publication_content(
+                resource_uri,
+                return_bytes=True,
+            )
+
+        assert result == expected_content
+
+    def test_lowercase_language_is_normalized(self, connector):
+        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+
+        with patch("bulletin.eurlex.repository._connector.requests.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.text = "<html></html>"
+            mock_get.return_value = mock_response
+
+            connector.fetch_publication_content(resource_uri, language="eng")
+
+        call_kwargs = mock_get.call_args[1]
+        assert call_kwargs["headers"]["Accept-Language"] == "eng"
+
+    def test_unsupported_language(self, connector):
+        with pytest.raises(QueryError, match="Unsupported language: 'XYZ'"):
+            connector.fetch_publication_content(
+                "http://publications.europa.eu/resource/celex/52025M12135",
+                language="XYZ",
+            )
+
+    def test_empty_resource_uri(self, connector):
+        with pytest.raises(QueryError, match="resource_uri cannot be empty"):
+            connector.fetch_publication_content("   ")
+
+    def test_invalid_max_size(self, connector):
+        with pytest.raises(QueryError, match="max_size must be a positive integer"):
+            connector.fetch_publication_content(
+                "http://publications.europa.eu/resource/celex/52025M12135",
+                max_size=0,
+            )
+
+    def test_http_error(self, connector):
+        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+
+        with patch("bulletin.eurlex.repository._connector.requests.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            http_error = requests.exceptions.HTTPError("404 Client Error")
+            http_error.response = mock_response
+            mock_response.raise_for_status.side_effect = http_error
+            mock_get.return_value = mock_response
+
+            with pytest.raises(EndpointError) as exc_info:
+                connector.fetch_publication_content(resource_uri)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.endpoint == resource_uri
+        assert "HTTP 404" in str(exc_info.value)
+
+    def test_connection_error(self, connector):
+        resource_uri = "http://publications.europa.eu/resource/celex/52025M12135"
+
+        with patch("bulletin.eurlex.repository._connector.requests.get") as mock_get:
+            mock_get.side_effect = requests.exceptions.ConnectionError("Failed")
+
+            with pytest.raises(EndpointError) as exc_info:
+                connector.fetch_publication_content(resource_uri)
+
+        assert exc_info.value.status_code is None
+        assert exc_info.value.endpoint == resource_uri
+        assert "Failed to reach Cellar REST API" in str(exc_info.value)
+
+
 class TestExecuteQuery:
     """Tests for execute_query method."""
 
@@ -112,7 +248,9 @@ class TestExecuteQuery:
     def test_connection_error(self, connector):
         query = "SELECT * WHERE { ?s ?p ?o } LIMIT 1"
         with patch("bulletin.eurlex.repository._connector.requests.post") as mock_post:
-            mock_post.side_effect = requests.exceptions.ConnectionError("Failed to connect")
+            mock_post.side_effect = requests.exceptions.ConnectionError(
+                "Failed to connect"
+            )
             with pytest.raises(EndpointError) as exc_info:
                 connector.execute_query(query)
             assert exc_info.value.status_code is None
@@ -130,7 +268,7 @@ class TestExecuteQuery:
         query = "SELECT * WHERE { ?s ?p ?o } LIMIT 1"
         expected_response = {
             "head": {"vars": ["s", "p", "o"]},
-            "results": {"bindings": []}
+            "results": {"bindings": []},
         }
         with patch("bulletin.eurlex.repository._connector.requests.post") as mock_post:
             mock_response = MagicMock()
@@ -169,7 +307,9 @@ class TestExecuteQueryIntegration:
         assert "HTTP 400" in str(exc_info.value)
 
     def test_unreachable_endpoint(self):
-        fake_connector = EurlexConnector(endpoint="https://esto-no-existe.europa.eu/sparql")
+        fake_connector = EurlexConnector(
+            endpoint="https://esto-no-existe.europa.eu/sparql"
+        )
         with pytest.raises(EndpointError) as exc_info:
             fake_connector.execute_query("SELECT * WHERE { ?s ?p ?o } LIMIT 1")
         assert exc_info.value.status_code is None


### PR DESCRIPTION
This pull request adds the ability to fetch the full content stream of EU legal acts using either a CELEX id or resource URI, significantly extending the EUR-Lex client’s capabilities. It introduces new API methods, updates the repository connector to support REST publication retrieval, and provides usage examples and tests. Documentation and sample scripts have also been updated to reflect and demonstrate the new functionality.

**New feature: Fetching act content**
- Added the `get_act_content` method to `EurlexBulletinClient`, allowing users to retrieve the publication content stream (HTML or binary) for an act by CELEX id or URI, with options for language, size limit, and raw bytes.
- Implemented `build_act_content_url` and `fetch_publication_content` in `EurlexConnector` to construct resource URLs and fetch content from the Cellar REST API, handling errors and response decoding.

**Documentation and examples**
- Updated `README.md`, `docs/index.md`, and `docs/api/eurlex.md` to document the new content-fetching feature and reference the Cellar REST API. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R20) [[3]](diffhunk://#diff-fd42cc46bb691d2f9c1d47f2d78f7975d4a71cbf6846110809743beaa4fb82b9L6-R8)
- Expanded code examples in `README.md`, `docs/getting-started.md`, and `scripts/run_eurlex.py` to demonstrate how to fetch act content and use new filters and output formats. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R100) [[3]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3R70-R81) [[4]](diffhunk://#diff-4792579c0a69725a580cf398ac6991513efcef94060a2c540b07aa5f91947311L13-R16) [[5]](diffhunk://#diff-4792579c0a69725a580cf398ac6991513efcef94060a2c540b07aa5f91947311L23-R29) [[6]](diffhunk://#diff-4792579c0a69725a580cf398ac6991513efcef94060a2c540b07aa5f91947311R50-R83)

**Testing**
- Added a new test class `TestGetActContent` to verify fetching act content by CELEX id and URI, including support for binary content.

**Repository connector improvements**
- Refactored and extended the connector to support both SPARQL and REST API endpoints, including better error handling and parameter validation. [[1]](diffhunk://#diff-9b508c3805bb1125d7a49c3cba3b1b1556de5caae7166e80439f72f602c4aaaaL1-R24) [[2]](diffhunk://#diff-9b508c3805bb1125d7a49c3cba3b1b1556de5caae7166e80439f72f602c4aaaaL77-R89) [[3]](diffhunk://#diff-9b508c3805bb1125d7a49c3cba3b1b1556de5caae7166e80439f72f602c4aaaaL240-R341) [[4]](diffhunk://#diff-9b508c3805bb1125d7a49c3cba3b1b1556de5caae7166e80439f72f602c4aaaaL275-R378)

**Miscellaneous**
- Minor updates to example scripts and notebooks for consistency and demonstration purposes. [[1]](diffhunk://#diff-0f661b20620195293d406cd11f80424cd9f1ad5f41e6852e40de36f5c911f040L48-R48) [[2]](diffhunk://#diff-0f661b20620195293d406cd11f80424cd9f1ad5f41e6852e40de36f5c911f040R60-R70) [[3]](diffhunk://#diff-0f661b20620195293d406cd11f80424cd9f1ad5f41e6852e40de36f5c911f040L101-R112) [[4]](diffhunk://#diff-c9bebd0b36d63e911354ccdcbdf6d1529c55a0677a3d174706c5b40ddafa238eL50-R52)
Closes #19 