### PR TITLE
Feature/search categories and institutions by name

### DIFF
--- a/scripts/run_eurlex.py
+++ b/scripts/run_eurlex.py
@@ -88,6 +88,20 @@ def main() -> int:
     for act in today_acts:
         print(f"- {act.title} ({act.date}) {act.institution_label}")
     print("Today documents can be checked at https://eur-lex.europa.eu/oj/direct-access.html")
+    
+    '''
+    # Testing institution types with a search filter
+    institution_types = client.get_institution_types(language=language, search="environment")
+    print(f"Institution types containing 'environment': {len(institution_types)}")
+    for inst_type in institution_types:
+        print(f"- {inst_type.label} ({inst_type.code})")
+    
+    # Testing category types with a search filter
+    category_types = client.get_category_types(language=language, search="communication")
+    print(f"Category types containing 'communication': {len(category_types)}")
+    for cat_type in category_types:
+        print(f"- {cat_type.label} ({cat_type.code})")
+    '''
 
     return 0
 

--- a/src/bulletin/eurlex/api/client.py
+++ b/src/bulletin/eurlex/api/client.py
@@ -144,31 +144,33 @@ class EurlexBulletinClient:
         )
 
     def get_category_types(
-        self, language: str = DEFAULT_LANGUAGE
+        self, language: str = DEFAULT_LANGUAGE, search: Optional[str] = None
     ) -> list[CategoryType]:
         """Fetch the list of possible category types from the authority list. This method may last a few minutes due to the size of the authority list.
 
         Args:
             language: Language code (default: "ENG"). Examples: "ENG", "SPA", "FRA"...
+            search: Optional case-insensitive substring filter on category type labels.
 
         Returns:
             A list of CategoryType objects with 'code' and 'label' attributes.
         """
-        query = self._connector.build_category_types_query(language=language)
+        query = self._connector.build_category_types_query(language=language, search=search)
         response = self._connector.execute_query(query)
         return parse_category_types_results(response)
 
     def get_institution_types(
-        self, language: str = DEFAULT_LANGUAGE
+        self, language: str = DEFAULT_LANGUAGE, search: Optional[str] = None
     ) -> list[InstitutionType]:
         """Fetch the list of possible institution types from the authority list. This method may last a few minutes due to the size of the authority list.
 
         Args:
             language: Language code (default: "ENG"). Examples: "ENG", "SPA", "FRA"...
+            search: Optional case-insensitive substring filter on the label.
 
         Returns:
             A list of InstitutionType objects with 'code' and 'label' attributes.
         """
-        query = self._connector.build_institution_types_query(language=language)
+        query = self._connector.build_institution_types_query(language=language, search=search)
         response = self._connector.execute_query(query)
         return parse_institution_types_results(response)

--- a/src/bulletin/eurlex/repository/_connector.py
+++ b/src/bulletin/eurlex/repository/_connector.py
@@ -167,6 +167,15 @@ class EurlexConnector:
         )
     
     def _get_label_filter(self, var_name: str, search: Optional[str]) -> str:
+        """ Helper method for building specific query parts, such as filters and content URLs.
+        Args:
+        - var_name: The variable name used in the SPARQL query (e.g., "label").
+        - search: Optional search string for filtering results.
+
+        Returns:
+        - A SPARQL filter string based on the search parameter.
+            
+        """
         if search is None:
             return ""
         search = search.strip()
@@ -174,13 +183,13 @@ class EurlexConnector:
             raise QueryError("search filter cannot be empty.")
         escaped = _escape_sparql_literal(search)
         return f'FILTER(BOUND(?{var_name}) && CONTAINS(LCASE(STR(?{var_name})), LCASE("{escaped}")))'
-    
 
     def build_category_types_query(self, language: str = DEFAULT_LANGUAGE, search: Optional[str] = None) -> str:
         """Build a SPARQL query to fetch the list of category types.
 
         Args:
-            language: ISO language code (default: "ENG").
+            language: ISO language code (default: "ENG"). Examples: "ENG", "SPA", "FRA"...
+            search: Optional case-insensitive substring filter on category type labels.
 
         Returns:
             The SPARQL query string.
@@ -217,6 +226,7 @@ class EurlexConnector:
 
         Args:
             language: ISO language code (default: "ENG").
+            search: Optional case-insensitive substring filter on institution type labels.
 
         Returns:
             The SPARQL query string.

--- a/src/bulletin/eurlex/repository/_connector.py
+++ b/src/bulletin/eurlex/repository/_connector.py
@@ -165,8 +165,18 @@ class EurlexConnector:
             date_filters_str="\n  ".join(date_filters),
             filters_str="\n  ".join(filters),
         )
+    
+    def _get_label_filter(self, var_name: str, search: Optional[str]) -> str:
+        if search is None:
+            return ""
+        search = search.strip()
+        if not search:
+            raise QueryError("search filter cannot be empty.")
+        escaped = _escape_sparql_literal(search)
+        return f'FILTER(BOUND(?{var_name}) && CONTAINS(LCASE(STR(?{var_name})), LCASE("{escaped}")))'
+    
 
-    def build_category_types_query(self, language: str = DEFAULT_LANGUAGE) -> str:
+    def build_category_types_query(self, language: str = DEFAULT_LANGUAGE, search: Optional[str] = None) -> str:
         """Build a SPARQL query to fetch the list of category types.
 
         Args:
@@ -176,6 +186,8 @@ class EurlexConnector:
             The SPARQL query string.
         """
         lang_code = LANGUAGE_CODE_MAP.get(language, "en")
+
+        filter_line = self._get_label_filter("label", search)
 
         query = f"""
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
@@ -191,12 +203,13 @@ class EurlexConnector:
                 ?uri skos:prefLabel ?label .
                 FILTER(LANG(?label) = "{lang_code}")
             }}
+            {filter_line}
             }}
             ORDER BY ?code
         """
         return query
 
-    def build_institution_types_query(self, language: str = DEFAULT_LANGUAGE) -> str:
+    def build_institution_types_query(self, language: str = DEFAULT_LANGUAGE, search: Optional[str] = None) -> str:
         """Build a SPARQL query to fetch the list of institutions.
 
         Note: The corporate-body authority endpoint can be slow/unreliable.
@@ -209,6 +222,8 @@ class EurlexConnector:
             The SPARQL query string.
         """
         lang_code = LANGUAGE_CODE_MAP.get(language, "en")
+
+        filter_line = self._get_label_filter("label", search)
 
         query = f"""
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
@@ -224,6 +239,7 @@ class EurlexConnector:
                 ?uri skos:prefLabel ?label .
                 FILTER(LANG(?label) = "{lang_code}")
             }}
+            {filter_line}
             }}
             ORDER BY ?code
         """

--- a/tests/eurlex/test_client.py
+++ b/tests/eurlex/test_client.py
@@ -624,13 +624,37 @@ class TestGetCategoryTypes:
 
         result = client.get_category_types(language="ENG")
 
-        mock_instance.build_category_types_query.assert_called_once_with(language="ENG")
+        mock_instance.build_category_types_query.assert_called_once_with(
+            language="ENG", search=None
+        )
         mock_instance.execute_query.assert_called_once_with("CATEGORY_TYPES_QUERY")
         assert len(result) == 2
         assert result[0].code == "REG"
         assert result[0].label == "Regulation"
         assert result[1].code == "DIR"
         assert result[1].label == "Directive"
+
+    def test_fetches_category_types_with_search(self, client, mock_connector):
+        """Test fetching category types with a label search filter."""
+        mock_instance = mock_connector.return_value
+        mock_instance.build_category_types_query.return_value = "CATEGORY_TYPES_QUERY"
+        mock_instance.execute_query.return_value = {
+            "results": {
+                "bindings": [
+                    {"code": {"value": "REG"}, "label": {"value": "Regulation"}},
+                ]
+            }
+        }
+
+        result = client.get_category_types(language="ENG", search="regul")
+
+        mock_instance.build_category_types_query.assert_called_once_with(
+            language="ENG", search="regul"
+        )
+        mock_instance.execute_query.assert_called_once_with("CATEGORY_TYPES_QUERY")
+        assert len(result) == 1
+        assert result[0].code == "REG"
+        assert result[0].label == "Regulation"
 
 
 class TestGetInstitutionTypes:
@@ -654,7 +678,7 @@ class TestGetInstitutionTypes:
         result = client.get_institution_types(language="ENG")
 
         mock_instance.build_institution_types_query.assert_called_once_with(
-            language="ENG"
+            language="ENG", search=None
         )
         mock_instance.execute_query.assert_called_once_with("INSTITUTION_TYPES_QUERY")
         assert len(result) == 2
@@ -662,3 +686,27 @@ class TestGetInstitutionTypes:
         assert result[0].label == "Commission"
         assert result[1].code == "ECJ"
         assert result[1].label == "Court of Justice"
+
+    def test_fetches_institution_types_with_search(self, client, mock_connector):
+        """Test fetching institution types with a label search filter."""
+        mock_instance = mock_connector.return_value
+        mock_instance.build_institution_types_query.return_value = (
+            "INSTITUTION_TYPES_QUERY"
+        )
+        mock_instance.execute_query.return_value = {
+            "results": {
+                "bindings": [
+                    {"code": {"value": "COM"}, "label": {"value": "Commission"}},
+                ]
+            }
+        }
+
+        result = client.get_institution_types(language="ENG", search="comm")
+
+        mock_instance.build_institution_types_query.assert_called_once_with(
+            language="ENG", search="comm"
+        )
+        mock_instance.execute_query.assert_called_once_with("INSTITUTION_TYPES_QUERY")
+        assert len(result) == 1
+        assert result[0].code == "COM"
+        assert result[0].label == "Commission"

--- a/tests/eurlex/test_connector.py
+++ b/tests/eurlex/test_connector.py
@@ -92,6 +92,25 @@ class TestBuildCategoryTypesQuery:
         query = connector.build_category_types_query(language="SPA")
         assert 'FILTER(LANG(?label) = "es")' in query
 
+    def test_search_filters_by_label(self, connector):
+        query = connector.build_category_types_query(search="regulation")
+        assert (
+            'FILTER(BOUND(?label) && CONTAINS(LCASE(STR(?label)), '
+            'LCASE("regulation")))'
+        ) in query
+
+    def test_search_is_trimmed(self, connector):
+        query = connector.build_category_types_query(search="  directive  ")
+        assert 'LCASE("directive")' in query
+
+    def test_search_escapes_sparql_literal(self, connector):
+        query = connector.build_category_types_query(search='foo "bar" \\ baz')
+        assert 'LCASE("foo \\"bar\\" \\\\ baz")' in query
+
+    def test_empty_search_raises(self, connector):
+        with pytest.raises(QueryError, match="search filter cannot be empty"):
+            connector.build_category_types_query(search="  ")
+
 
 class TestBuildInstitutionTypesQuery:
     """Tests for build_institution_types_query method."""
@@ -106,6 +125,25 @@ class TestBuildInstitutionTypesQuery:
         query = connector.build_institution_types_query(language="SPA")
         assert "corporate-body" in query
         assert 'FILTER(LANG(?label) = "es")' in query
+
+    def test_search_filters_by_label(self, connector):
+        query = connector.build_institution_types_query(search="commission")
+        assert (
+            'FILTER(BOUND(?label) && CONTAINS(LCASE(STR(?label)), '
+            'LCASE("commission")))'
+        ) in query
+
+    def test_search_is_trimmed(self, connector):
+        query = connector.build_institution_types_query(search="  court  ")
+        assert 'LCASE("court")' in query
+
+    def test_search_escapes_sparql_literal(self, connector):
+        query = connector.build_institution_types_query(search='foo "bar" \\ baz')
+        assert 'LCASE("foo \\"bar\\" \\\\ baz")' in query
+
+    def test_empty_search_raises(self, connector):
+        with pytest.raises(QueryError, match="search filter cannot be empty"):
+            connector.build_institution_types_query(search="  ")
 
 
 class TestBuildActContentUrl:


### PR DESCRIPTION
This pull request adds support for filtering institution types and category types by label substring in the EUR-Lex client and repository, making it easier to search for specific entries. The changes include updates to the API, query-building logic, and extensive new tests to ensure correct filtering and error handling.

**API and Query Enhancements:**

* Added an optional `search` parameter to `get_category_types` and `get_institution_types` in `client.py`, allowing users to filter results by a case-insensitive substring of the label. The parameter is passed through to the underlying query builder.
* Updated `build_category_types_query` and `build_institution_types_query` in `_connector.py` to accept a `search` parameter and filter results using a SPARQL `FILTER` clause. Introduced a helper method `_get_label_filter` to construct and validate the filter, raising an error for empty search strings and escaping SPARQL literals. [[1]](diffhunk://#diff-9b508c3805bb1125d7a49c3cba3b1b1556de5caae7166e80439f72f602c4aaaaL169-R179) [[2]](diffhunk://#diff-9b508c3805bb1125d7a49c3cba3b1b1556de5caae7166e80439f72f602c4aaaaR190-R191) [[3]](diffhunk://#diff-9b508c3805bb1125d7a49c3cba3b1b1556de5caae7166e80439f72f602c4aaaaR206-R212) [[4]](diffhunk://#diff-9b508c3805bb1125d7a49c3cba3b1b1556de5caae7166e80439f72f602c4aaaaR226-R227) [[5]](diffhunk://#diff-9b508c3805bb1125d7a49c3cba3b1b1556de5caae7166e80439f72f602c4aaaaR242)

**Testing Improvements:**

* Added new unit tests in `test_client.py` to verify that the client correctly passes the `search` parameter, returns filtered results, and integrates with the query builder. [[1]](diffhunk://#diff-7ef2236a3d0570947628eb816bf8f890bcc245480a25ac15eb241c237ce10e8cL627-R658) [[2]](diffhunk://#diff-7ef2236a3d0570947628eb816bf8f890bcc245480a25ac15eb241c237ce10e8cL657-R712)
* Added new tests in `test_connector.py` to ensure the query builder correctly applies, trims, and escapes the search filter, and raises an error for empty searches. [[1]](diffhunk://#diff-c9bebd0b36d63e911354ccdcbdf6d1529c55a0677a3d174706c5b40ddafa238eR95-R113) [[2]](diffhunk://#diff-c9bebd0b36d63e911354ccdcbdf6d1529c55a0677a3d174706c5b40ddafa238eR129-R147)

**Other:**

* Commented-out sample code in `run_eurlex.py` demonstrates how to use the new search functionality for both institution and category types.
Closes #22 