### PR TITLE
fix: update act URI handling to use rawAct in queries

### DIFF
--- a/src/bulletin/eurlex/api/models.py
+++ b/src/bulletin/eurlex/api/models.py
@@ -65,13 +65,8 @@ class EurlexOfficialAct:
     @classmethod
     def _from_binding(cls, binding: Mapping[str, Any]) -> EurlexOfficialAct:
         """Build an EurlexOfficialAct from one SPARQL binding item."""
-        raw_act_uri = _required_value(binding, "act")
-        act_uri = raw_act_uri.replace(
-            "http://publications.europa.eu/resource/eli/",
-            "https://eur-lex.europa.eu/eli/"
-        )
         return cls(
-            act_uri=act_uri,
+            act_uri=_required_value(binding, "act"),
             celex_uri=_optional_value(binding, "celexAct") or _optional_value(binding, "celex") or "",
             act_number=_optional_value(binding, "actNumber"),
             title=_required_value(binding, "title"),

--- a/src/bulletin/eurlex/repository/_connector.py
+++ b/src/bulletin/eurlex/repository/_connector.py
@@ -113,10 +113,11 @@ class EurlexConnector:
                 cdm:official-journal-act_date_publication
                 | cdm:resource_legal_published_in_official-journal/cdm:publication_general_date_publication
             ) ?date ;
-                   owl:sameAs ?act .
+                   owl:sameAs ?rawAct .
             {date_filters_str}
 
-            FILTER(STRSTARTS(STR(?act), "http://publications.europa.eu/resource/eli/"))
+            FILTER(STRSTARTS(STR(?rawAct), "http://publications.europa.eu/resource/eli/"))
+            BIND(REPLACE(STR(?rawAct), "http://publications.europa.eu/resource/eli/", "https://eur-lex.europa.eu/eli/") AS ?act)
 
             OPTIONAL {{
                 ?c_act owl:sameAs ?celexAct .

--- a/tests/eurlex/test_connector.py
+++ b/tests/eurlex/test_connector.py
@@ -26,7 +26,7 @@ class TestBuildActsQuery:
     def test_uses_eli_act_uri_and_optional_celex_uri(self, connector):
         query = connector.build_acts_query("2024-01-01")
         assert (
-            'FILTER(STRSTARTS(STR(?act), "http://publications.europa.eu/resource/eli/"))'
+            'FILTER(STRSTARTS(STR(?rawAct), "http://publications.europa.eu/resource/eli/"))'
             in query
         )
         assert (


### PR DESCRIPTION
This pull request updates how ELI act URIs are handled in the Eurlex connector and related tests. The main change is to move the transformation of act URIs from the model layer to the query layer, ensuring that act URIs are normalized to the `https://eur-lex.europa.eu/eli/` format directly in the SPARQL query. This simplifies the model code and makes the URI format consistent throughout the codebase.

**Query and URI normalization changes:**

* In `build_acts_query`, the SPARQL query now binds `?act` to the normalized URI by replacing the prefix in `?rawAct`, and the filter is updated to use `?rawAct` instead of `?act`.
* The test `test_uses_eli_act_uri_and_optional_celex_uri` is updated to check for the new filter condition using `?rawAct`.

**Model simplification:**

* The `_from_binding` method in `EurlexOfficialAct` no longer performs URI normalization, as this is now handled in the query. It directly assigns the value of `act` from the binding.

Closes #28 